### PR TITLE
Properly handle If-None-Match

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -47,7 +47,7 @@ module Rack
       headers = env.reject do |k, v|
         !(/^HTTP_[A-Z_]+$/ === k)
       end.map do |k, v|
-        [k.sub(/^HTTP_/, ""), v]
+        [reconstruct_header_name(k), v]
       end.inject(Utils::HeaderHash.new) do |hash, k_v|
         k, v = k_v
         hash[k] = v
@@ -57,6 +57,10 @@ module Rack
       x_forwarded_for = (headers["X-Forwarded-For"].to_s.split(/, +/) << env["REMOTE_ADDR"]).join(", ")
 
       headers.merge!("X-Forwarded-For" =>  x_forwarded_for)
+    end
+
+    def reconstruct_header_name(name)
+      name.sub(/^HTTP_/, "").gsub("_", "-")
     end
 
   end

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -19,4 +19,14 @@ class RackProxyTest < Test::Unit::TestCase
     assert last_response.ok?
     assert /Jacek Becela/ === last_response.body
   end
+
+  def test_header_reconstruction
+    proxy = Rack::Proxy.new
+
+    header = proxy.send(:reconstruct_header_name, "HTTP_ABC")
+    assert header == "ABC"
+
+    header = proxy.send(:reconstruct_header_name, "HTTP_ABC_D")
+    assert header == "ABC-D"
+  end
 end


### PR DESCRIPTION
So I was attempting to proxy the If-None-Match header and the current version doesn't appropriately recreate the header from the Rack environment. This is my attempt to fix that.
