### PR TITLE
Prevent nil headers from passing to Net::HTTP

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -49,7 +49,7 @@ module Rack
     
     def extract_http_request_headers(env)
       headers = env.reject do |k, v|
-        !(/^HTTP_[A-Z_]+$/ === k)
+        !(/^HTTP_[A-Z_]+$/ === k) || v.nil?
       end.map do |k, v|
         [reconstruct_header_name(k), v]
       end.inject(Utils::HeaderHash.new) do |hash, k_v|

--- a/test/net_http_hacked_test.rb
+++ b/test/net_http_hacked_test.rb
@@ -17,7 +17,7 @@ class NetHttpHackedTest < Test::Unit::TestCase
 
     assert headers.size > 0
     assert headers["content-type"] == "text/html; charset=UTF-8"
-    assert headers["content-length"].to_i > 0
+    assert !headers["date"].nil?
     
     # Body
     chunks = []

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -5,7 +5,6 @@ class RackProxyTest < Test::Unit::TestCase
   class TrixProxy < Rack::Proxy
     def rewrite_env(env)
       env["HTTP_HOST"] = "trix.pl"
-      
       env
     end
   end
@@ -28,5 +27,19 @@ class RackProxyTest < Test::Unit::TestCase
 
     header = proxy.send(:reconstruct_header_name, "HTTP_ABC_D")
     assert header == "ABC-D"
+  end
+
+  def test_extract_http_request_headers
+    proxy = Rack::Proxy.new
+    env = {
+      'NOT-HTTP-HEADER' => 'test-value',
+      'HTTP_ACCEPT' => 'text/html',
+      'HTTP_CONNECTION' => nil
+    }
+
+    headers = proxy.send(:extract_http_request_headers, env)
+    assert headers.key?('ACCEPT')
+    assert !headers.key?('CONNECTION')
+    assert !headers.key?('NOT-HTTP-HEADER')
   end
 end


### PR DESCRIPTION
Net::HTTP#initialize_http_header crashes when you try to create a nil-valued header.  An upstream middleware (like Rack::Cache) tends to send those values. 

This patch prevents those headers from passing through.
