### PR TITLE
Test HttpStreamingResponseTest#test_streaming is broken

### DIFF
--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -16,8 +16,9 @@ class HttpStreamingResponseTest < Test::Unit::TestCase
     headers = @response.headers
     
     assert headers.size > 0
-    assert headers["content-type"] == "text/html"
-    assert headers["CoNtEnT-TyPe"] == "text/html"
+
+    assert headers["content-type"] == "text/html;charset=utf-8"
+    assert headers["CoNtEnT-TyPe"] == headers["content-type"]
     assert headers["content-length"].to_i > 0
     
     # Body


### PR DESCRIPTION
The test HttpStreamingResponseTest#test_streaming is broken. Apparently trix.pl changed their content-type. I've updated the look for the new content-type.
