### PR TITLE
Exception for POST without content-length

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -35,7 +35,7 @@ module Rack
       # Setup body
       if target_request.request_body_permitted? && source_request.body
         target_request.body_stream    = source_request.body
-        target_request.content_length = source_request.content_length
+        target_request.content_length = source_request.content_length.to_i
         target_request.content_type   = source_request.content_type if source_request.content_type
       end
       

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -42,4 +42,10 @@ class RackProxyTest < Test::Unit::TestCase
     assert !headers.key?('CONNECTION')
     assert !headers.key?('NOT-HTTP-HEADER')
   end
+
+  def test_handles_missing_content_length
+    assert_nothing_thrown do
+      post "/", nil, "CONTENT_LENGTH" => nil
+    end
+  end
 end


### PR DESCRIPTION
When POSTing through a Rack::Proxy with a `nil` CONTENT_LENGTH, an exception is raised:

```
ArgumentError: Content-Length not given and Transfer-Encoding is not `chunked'
    rack-proxy/lib/net_http_hacked.rb:51:in `begin_request_hacked'
    rack-proxy/lib/rack/http_streaming_response.rb:54:in `response'
    rack-proxy/lib/rack/http_streaming_response.rb:14:in `status'
    rack-proxy/lib/rack/proxy.rb:47:in `perform_request'
    rack-proxy/lib/rack/proxy.rb:11:in `call'
```

I'm not sure if this is limited to a specific ruby version, but I'm using 1.9.3.
