### PR TITLE
Treat header values as arrays

### DIFF
--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -9,21 +9,21 @@ module Rack
     def initialize(request, host, port = nil)
       @request, @host, @port = request, host, port
     end
-    
+
     def status
       response.code.to_i
     end
-    
+
     def headers
       h = Utils::HeaderHash.new
-      
-      response.each_header do |k, v|
+
+      response.to_hash.each do |k, v|
         h[k] = v
       end
-      
+
       h
     end
-    
+
     def body
       self
     end
@@ -34,7 +34,7 @@ module Rack
     ensure
       session.end_request_hacked
     end
-    
+
     def to_s
       @body ||= begin
         lines = []
@@ -42,18 +42,18 @@ module Rack
         each do |line|
           lines << line
         end
-        
+
         lines.join
       end
     end
-    
+
     protected
-    
+
     # Net::HTTPResponse
     def response
       @response ||= session.begin_request_hacked(@request)
     end
-    
+
     # Net::HTTP
     def session
       @session ||= begin
@@ -62,7 +62,7 @@ module Rack
         http.start
       end
     end
-    
+
   end
 
 end

--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -2,46 +2,46 @@ require "test_helper"
 require "rack/http_streaming_response"
 
 class HttpStreamingResponseTest < Test::Unit::TestCase
-  
+
   def setup
     host, req = "trix.pl", Net::HTTP::Get.new("/")
     @response = Rack::HttpStreamingResponse.new(req, host)
   end
-  
+
   def test_streaming
     # Response status
     assert @response.status == 200
-    
+
     # Headers
     headers = @response.headers
-    
+
     assert headers.size > 0
 
-    assert headers["content-type"] == "text/html;charset=utf-8"
+    assert headers["content-type"] == ["text/html;charset=utf-8"]
     assert headers["CoNtEnT-TyPe"] == headers["content-type"]
-    assert headers["content-length"].to_i > 0
-    
+    assert headers["content-length"].first.to_i > 0
+
     # Body
     chunks = []
     @response.body.each do |chunk|
       chunks << chunk
     end
-    
+
     assert chunks.size > 0
     chunks.each do |chunk|
       assert chunk.is_a?(String)
     end
-    
-    
+
+
   end
-  
+
   def test_to_s
-    assert_equal @response.headers["Content-Length"].to_i, @response.body.to_s.size
+    assert_equal @response.headers["Content-Length"].first.to_i, @response.body.to_s.size
   end
-  
+
   def test_to_s_called_twice
     body = @response.body
     assert_equal body.to_s, body.to_s
   end
-  
+
 end


### PR DESCRIPTION
This fixes the case of multiple headers of the same name (set-cookie being the
real world example I ran into) getting all smooshed together into a single
(invalid) header. Net::HTTP tries to be smart and join such headers with a ",
", which isn't so bad when immediately consuming the results, but wreaks havoc
when passing those headers through the proxy.

Treating the header values as arrays fixes this issue, as Rack happily does
the right thing and passes back a separate header for each value it sees in
the array.

This definitely has the potential for breakage, as it implicitly changes the
header portion of the triplet passed to #rewrite_response.

I tried to figure out how to write a test for this and came up empty. Best bet
is probably to have your trix.pl endpoint return a double header and verify
that rack-proxy does the right thing with it.
