### PR TITLE
fix broken tests that were depending on trix.pl url to 200 instead of 30...

### DIFF
--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -4,7 +4,7 @@ require "rack/http_streaming_response"
 class HttpStreamingResponseTest < Test::Unit::TestCase
 
   def setup
-    host, req = "trix.pl", Net::HTTP::Get.new("/")
+    host, req = "www.trix.pl", Net::HTTP::Get.new("/")
     @response = Rack::HttpStreamingResponse.new(req, host)
   end
 

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -4,7 +4,7 @@ require "rack/proxy"
 class RackProxyTest < Test::Unit::TestCase
   class TrixProxy < Rack::Proxy
     def rewrite_env(env)
-      env["HTTP_HOST"] = "trix.pl"
+      env["HTTP_HOST"] = "www.trix.pl"
       env
     end
   end


### PR DESCRIPTION
Hi, two tests were failing because it appears you may have recently changed your webserver to 301 redirect trix.pl to www.trix.pl.

→ curl trix.pl
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>

<H1>301 Moved</H1>

The document has moved
<A HREF="http://www.trix.pl/">here</A>.
</BODY></HTML>
