### PR TITLE
Response refactoring

### DIFF
--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -10,9 +10,15 @@ module Rack
       @request, @host, @port = request, host, port
     end
 
-    def status
+    def body
+      self
+    end
+
+    def code
       response.code.to_i
     end
+    # #status is deprecated
+    alias_method :status, :code
 
     def headers
       h = Utils::HeaderHash.new
@@ -22,10 +28,6 @@ module Rack
       end
 
       h
-    end
-
-    def body
-      self
     end
 
     # Can be called only once!

--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -10,6 +10,7 @@ class HttpStreamingResponseTest < Test::Unit::TestCase
 
   def test_streaming
     # Response status
+    assert @response.code == 200
     assert @response.status == 200
 
     # Headers


### PR DESCRIPTION
`Proxy#perform_request` has gotten pretty big, specifically the `target_response` initialization. I've refactored that part a little, removing duplication.

The only substantive change was renaming `HttpStreamingResponse#status` to `#code`, so that its API matched `Net::HTTP#code`. I've added an alias so that `#status` keeps woking, in case someone's using it externally.
