### PR TITLE
Refactor creation of the response object

### DIFF
--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -10,9 +10,15 @@ module Rack
       @request, @host, @port = request, host, port
     end
 
-    def status
+    def body
+      self
+    end
+
+    def code
       response.code.to_i
     end
+    # #status is deprecated
+    alias_method :status, :code
 
     def headers
       h = Utils::HeaderHash.new
@@ -22,10 +28,6 @@ module Rack
       end
 
       h
-    end
-
-    def body
-      self
     end
 
     # Can be called only once!

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -51,32 +51,21 @@ module Rack
         target_request.content_type   = source_request.content_type if source_request.content_type
       end
 
+      backend = @backend || source_request
 
-      # Create a streaming response (the actual network communication is deferred, a.k.a. streamed)
+      # Create the response
       if @streaming
-        if @backend
-          target_response = HttpStreamingResponse.new(target_request, @backend.host, @backend.port)
-
-          target_response.use_ssl = "https" == @backend.scheme
-        else
-          target_response = HttpStreamingResponse.new(target_request, source_request.host, source_request.port)
-
-          target_response.use_ssl = "https" == source_request.scheme
-        end
-
-        triplet = [target_response.status, target_response.headers, target_response.body]
+        # streaming response (the actual network communication is deferred, a.k.a. streamed)
+        target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port)
+        target_response.use_ssl = backend.scheme == "https"
       else
-        host = (@backend && @backend.host) || source_request.host
-        port = (@backend && @backend.port) || source_request.port
-        target_response = Net::HTTP.start(host, port) do |http|
+        target_response = Net::HTTP.start(backend.host, backend.port) do |http|
           http.request(target_request)
         end
-
-        headers = (target_response.respond_to?(:headers) && target_response.headers) || {}
-        triplet = [target_response.code, headers, target_response.body]
       end
 
-      triplet
+      headers = (target_response.respond_to?(:headers) && target_response.headers) || {}
+      [target_response.code, headers, target_response.body]
     end
 
     def extract_http_request_headers(env)

--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -10,6 +10,7 @@ class HttpStreamingResponseTest < Test::Unit::TestCase
 
   def test_streaming
     # Response status
+    assert @response.code == 200
     assert @response.status == 200
 
     # Headers


### PR DESCRIPTION
`Proxy#perform_request` has gotten pretty big, specifically the `target_response` initialization. I've refactored that part a little, removing duplication.

The only meaningful change was renaming `HttpStreamingResponse#status` to `#code`, so that its API matches `Net::HTTP#code`. I've added an alias so that `#status` keeps woking, in case someone's using it externally.
