### PR TITLE
Allow SSL for non-streaming requests

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -59,7 +59,7 @@ module Rack
         target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port)
         target_response.use_ssl = backend.scheme == "https"
       else
-        target_response = Net::HTTP.start(backend.host, backend.port) do |http|
+        target_response = Net::HTTP.start(backend.host, backend.port, :use_ssl => backend.scheme == "https") do |http|
           http.request(target_request)
         end
       end


### PR DESCRIPTION
A minor change to allow using HTTPS/SSL for non-streaming requests.

I started to write a test, but I wasn't sure what would be a good HTTPS address to test against. I tried www.trix.pl, but there were some certificate issues that prevented a test against that domain from passing.

I manually tested the change against an in house HTTPS server and there were no issues in ruby-1.9.3-p448 or ruby-2.0.0-p247 running on Ubuntu 12.04.

If you have a domain suggestion, I'd be happy to write a test.

Also, if you prefer I refactor the code to check for SSL in only one place, I can do that too.
