### PR TITLE
Refactor and test https for streaming and full requests

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -52,14 +52,15 @@ module Rack
       end
 
       backend = @backend || source_request
+      use_ssl = backend.scheme == "https"
 
       # Create the response
       if @streaming
         # streaming response (the actual network communication is deferred, a.k.a. streamed)
         target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port)
-        target_response.use_ssl = backend.scheme == "https"
+        target_response.use_ssl = use_ssl
       else
-        target_response = Net::HTTP.start(backend.host, backend.port, :use_ssl => backend.scheme == "https") do |http|
+        target_response = Net::HTTP.start(backend.host, backend.port, :use_ssl => use_ssl) do |http|
           http.request(target_request)
         end
       end


### PR DESCRIPTION
Cleanup and tests as promised.

Again, all tests pass on Ubuntu 12.04 with 1.9.3-p448 and 2.0.0-p247.
