### PR TITLE
Record correct version number in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-proxy (0.5.5)
+    rack-proxy (0.5.6)
       rack
 
 GEM


### PR DESCRIPTION
Hey @ncr, as mentioned [here](https://github.com/pvdb/rack-proxy/commit/3ee895c2adaba3b5e3bcbec69216d87c75023050#commitcomment-4297393) the wrong version number is recorded in the `Gemfile.lock`... this PR fixes that inconsistency
