### PR TITLE
Set headers propery for non-streaming requests

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -73,7 +73,7 @@ module Rack
         end
       end
 
-      headers = (target_response.respond_to?(:headers) && target_response.headers) || {}
+      headers = (target_response.respond_to?(:headers) && target_response.headers) || target_response.to_hash
       body    = target_response.body
       body    = [body] unless body.respond_to?(:each)
 

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -28,6 +28,13 @@ class RackProxyTest < Test::Unit::TestCase
     assert_match(/Jacek Becela/, last_response.body)
   end
 
+  def test_http_full_request_headers
+    app(:streaming => false)
+    app.host = 'www.google.com'
+    get "/"
+    assert !Array(last_response['Set-Cookie']).empty?, 'Google always sets a cookie, yo. Where my cookies at?!'
+  end
+
   def test_https_streaming
     app.host = 'www.apple.com'
     get 'https://example.com'


### PR DESCRIPTION
I'm not exactly sure why `streaming` is default -- it seems to cause strange errors in different environments for me, and is fully incompatible with WebMock and VCR (as noted in the readme).  However, non-streaming requests work fine with WebMock and VCR.

As a result, I've recently begun setting `streaming = false`, but then I found that non-streaming responses don't respond to the `headers` method, meaning all headers from the response are essentially dropped (and not proxied).

If you [check out the net/http](http://ruby-doc.org/stdlib-2.0.0/libdoc/net/http/rdoc/Net/HTTP.html#label-Response+Data) docs, it's clear that `to_hash` is the intended method for attaining headers.

I've included a test that fails if you change the proxy.rb request back to what it was before.
