### PR TITLE
normalize headers from a proxied request so that rack doesnt choke on them

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -24,6 +24,13 @@ module Rack
         headers.merge!("X-Forwarded-For" =>  x_forwarded_for)
       end
 
+      def normalize_headers(headers)
+        mapped = headers.map do|k, v| 
+          [k, if v.is_a? Array then v.first else v end]
+        end
+        Hash[mapped]
+      end
+
       protected
 
       def reconstruct_header_name(name)
@@ -97,7 +104,7 @@ module Rack
         end
       end
 
-      headers = (target_response.respond_to?(:headers) && target_response.headers) || target_response.to_hash
+      headers = (target_response.respond_to?(:headers) && target_response.headers) || self.class.normalize_headers(target_response.to_hash)
       body    = target_response.body
       body    = [body] unless body.respond_to?(:each)
 


### PR DESCRIPTION
This is a preliminary patch to sanitize/normalize the output of NET::HTTP class when proxying a request.

At the moment, it only gets the first element of the array if a header value is an array. Arrays with multiple items should be joined (I can't remember what character with though..., ';'?)

There is a gist here with the failing test case:

https://gist.github.com/nhemsley/9129335
