### PR TITLE
Join multiple headers instead of dropping them

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -26,7 +26,7 @@ module Rack
 
       def normalize_headers(headers)
         mapped = headers.map do|k, v| 
-          [k, if v.is_a? Array then v.first else v end]
+          [k, if v.is_a? Array then v.join("\n") else v end]
         end
         Hash[mapped]
       end

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -73,6 +73,15 @@ class RackProxyTest < Test::Unit::TestCase
     assert !headers.key?('NOT-HTTP-HEADER')
   end
 
+  def test_duplicate_headers
+    proxy_class = Rack::Proxy
+    env = { 'Set-Cookie' => ["cookie1=foo", "cookie2=bar"] }
+
+    headers = proxy_class.normalize_headers(env)
+    assert headers['Set-Cookie'].include?('cookie2'), "Join multiple cookies with newlines"
+  end
+
+
   def test_handles_missing_content_length
     assert_nothing_thrown do
       post "/", nil, "CONTENT_LENGTH" => nil


### PR DESCRIPTION
The Rack spec states that headers with multiple values should be joined with newlines. The current behavior is to drop all but the first header.

https://github.com/rack/rack/blob/master/SPEC#L209
