### PR TITLE
add ability to set read_timout fot Net:HTTP - resolves #43

### DIFF
--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -6,6 +6,7 @@ module Rack
   class HttpStreamingResponse
     attr_accessor :use_ssl
     attr_accessor :verify_mode
+    attr_accessor :read_timeout
 
     def initialize(request, host, port = nil)
       @request, @host, @port = request, host, port
@@ -63,6 +64,7 @@ module Rack
         http = Net::HTTP.new @host, @port
         http.use_ssl = self.use_ssl
         http.verify_mode = self.verify_mode
+        http.read_timeout = self.read_timeout
         http.start
       end
     end


### PR DESCRIPTION
I can now set the read_timeout attribute using the following snippet. The attribute read_timeout [defaults to 60 seconds](http://www.ruby-doc.org/stdlib-2.1.1/libdoc/net/http/rdoc/Net/HTTP.html#method-i-read_timeout-3D).

```
class AppProxy < Rack::Proxy
  def rewrite_env(env)
    env["http.read_timeout"]=300
    env
  end
end
```
