### PR TITLE
backend can be passed as env key

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -84,7 +84,7 @@ module Rack
         target_request.body_stream.rewind
       end
 
-      backend = @backend || source_request
+      backend = env.delete('rack.backend') || @backend || source_request
       use_ssl = backend.scheme == "https"
       ssl_verify_none = (env.delete('rack.ssl_verify_none') || @ssl_verify_none) == true
 


### PR DESCRIPTION
This patch adds ability to define backend separately per each request.
