### PR TITLE
Return HeaderHash in Proxy::normalize_headers

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -25,10 +25,10 @@ module Rack
       end
 
       def normalize_headers(headers)
-        mapped = headers.map do|k, v| 
+        mapped = headers.map do |k, v|
           [k, if v.is_a? Array then v.join("\n") else v end]
         end
-        Hash[mapped]
+        Utils::HeaderHash.new Hash[mapped]
       end
 
       protected

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -49,6 +49,16 @@ class RackProxyTest < Test::Unit::TestCase
     assert_match(/(itunes|iphone|ipod|mac|ipad)/, last_response.body)
   end
 
+  def test_normalize_headers
+    proxy_class = Rack::Proxy
+    headers = { 'header_array' => ['first_entry'], 'header_non_array' => :entry }
+
+    normalized_headers = proxy_class.send(:normalize_headers, headers)
+    assert normalized_headers.instance_of?(Rack::Utils::HeaderHash)
+    assert normalized_headers['header_array'] == 'first_entry'
+    assert normalized_headers['header_non_array'] == :entry
+  end
+
   def test_header_reconstruction
     proxy_class = Rack::Proxy
 


### PR DESCRIPTION
Otherwise we have differing behaviour in the triplet returned by
`Proxy#perform_request`, which may be unexpected by other middlewares
down the pipe.

What do you think?
