### PR TITLE
Pass through headers with alphanumeric names

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -10,7 +10,7 @@ module Rack
     class << self
       def extract_http_request_headers(env)
         headers = env.reject do |k, v|
-          !(/^HTTP_[A-Z_]+$/ === k) || v.nil?
+          !(/^HTTP_[A-Z0-9_]+$/ === k) || v.nil?
         end.map do |k, v|
           [reconstruct_header_name(k), v]
         end.inject(Utils::HeaderHash.new) do |hash, k_v|

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -74,11 +74,13 @@ class RackProxyTest < Test::Unit::TestCase
     env = {
       'NOT-HTTP-HEADER' => 'test-value',
       'HTTP_ACCEPT' => 'text/html',
-      'HTTP_CONNECTION' => nil
+      'HTTP_CONNECTION' => nil,
+      'HTTP_CONTENT_MD5' => 'deadbeef'
     }
 
     headers = proxy_class.extract_http_request_headers(env)
     assert headers.key?('ACCEPT')
+    assert headers.key?('CONTENT-MD5')
     assert !headers.key?('CONNECTION')
     assert !headers.key?('NOT-HTTP-HEADER')
   end


### PR DESCRIPTION
For example, 'Content-MD5' is a common header that is currently being
swallowed by the proxy.