### PR TITLE
Add ssl_version override to Rack::Proxy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-proxy (0.5.17)
+    rack-proxy (0.5.18)
       rack
 
 GEM

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -7,6 +7,7 @@ module Rack
     attr_accessor :use_ssl
     attr_accessor :verify_mode
     attr_accessor :read_timeout
+    attr_accessor :ssl_version
 
     def initialize(request, host, port = nil)
       @request, @host, @port = request, host, port
@@ -65,6 +66,11 @@ module Rack
         http.use_ssl = self.use_ssl
         http.verify_mode = self.verify_mode
         http.read_timeout = self.read_timeout
+        if self.use_ssl
+          if OpenSSL::SSL::SSLContext::METHODS.include? self.ssl_version
+            http.ssl_version = self.ssl_version
+          end
+        end
         http.start
       end
     end

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -66,11 +66,7 @@ module Rack
         http.use_ssl = self.use_ssl
         http.verify_mode = self.verify_mode
         http.read_timeout = self.read_timeout
-        if self.use_ssl
-          if OpenSSL::SSL::SSLContext::METHODS.include? self.ssl_version
-            http.ssl_version = self.ssl_version
-          end
-        end
+        http.ssl_version = self.ssl_version if self.use_ssl
         http.start
       end
     end

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -42,9 +42,9 @@ module Rack
     def initialize(opts = {})
       @streaming = opts.fetch(:streaming, true)
       @ssl_verify_none = opts.fetch(:ssl_verify_none, false)
-      @backend = opts[:backend] ? URI(opts[:backend]) : nil
+      @backend = URI(opts[:backend]) if opts[:backend]
       @read_timeout = opts.fetch(:read_timeout, 60)
-      @ssl_version = opts[:ssl_version] ? opts[:ssl_version] : nil
+      @ssl_version = opts[:ssl_version] if opts[:ssl_version]
     end
 
     def call(env)
@@ -100,13 +100,13 @@ module Rack
         target_response.verify_mode = OpenSSL::SSL::VERIFY_NONE if use_ssl && ssl_verify_none
         target_response.ssl_version = @ssl_version if @ssl_version
       else
-        serial = Net::HTTP.new(backend.host, backend.port)
-        serial.use_ssl = use_ssl if use_ssl
-        serial.read_timeout = read_timeout
-        serial.verify_mode = OpenSSL::SSL::VERIFY_NONE if use_ssl && ssl_verify_none
-        serial.ssl_version = @ssl_version if @ssl_version
+        http = Net::HTTP.new(backend.host, backend.port)
+        http.use_ssl = use_ssl if use_ssl
+        http.read_timeout = read_timeout
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE if use_ssl && ssl_verify_none
+        http.ssl_version = @ssl_version if @ssl_version
 
-        target_response = serial.start() do |http|
+        target_response = http.start do
           http.request(target_request)
         end
       end

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -42,9 +42,9 @@ module Rack
     def initialize(opts = {})
       @streaming = opts.fetch(:streaming, true)
       @ssl_verify_none = opts.fetch(:ssl_verify_none, false)
-      @backend = URI(opts[:backend]) if opts[:backend]
+      @backend = opts[:backend] ? URI(opts[:backend]) : nil
       @read_timeout = opts.fetch(:read_timeout, 60)
-      @ssl_version = opts[:ssl_version] if opts[:ssl_version]
+      @ssl_version = opts[:ssl_version] ? opts[:ssl_version] : nil
     end
 
     def call(env)
@@ -103,10 +103,9 @@ module Rack
         start_opts = use_ssl ? {:use_ssl => use_ssl} : {}
         start_opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if use_ssl && ssl_verify_none
         start_opts[:read_timeout] = read_timeout
-        start_opts[:ssl_version] = @ssl_version
-#        http = Net::HTTP.new(backend.host, backend.port)
+        start_opts[:ssl_version] = @ssl_version if @ssl_version
+
         target_response = Net::HTTP.start(backend.host, backend.port, start_opts) do |http|
-          http.ssl_version = @ssl_version if @ssl_version
           http.request(target_request)
         end
       end

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -98,14 +98,15 @@ module Rack
         target_response.use_ssl = use_ssl
         target_response.read_timeout = read_timeout
         target_response.verify_mode = OpenSSL::SSL::VERIFY_NONE if use_ssl && ssl_verify_none
-        target_response.ssl_version = @ssl_version
+        target_response.ssl_version = @ssl_version if @ssl_version
       else
-        start_opts = use_ssl ? {:use_ssl => use_ssl} : {}
-        start_opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if use_ssl && ssl_verify_none
-        start_opts[:read_timeout] = read_timeout
-        start_opts[:ssl_version] = @ssl_version if @ssl_version
+        serial = Net::HTTP.new(backend.host, backend.port)
+        serial.use_ssl = use_ssl if use_ssl
+        serial.read_timeout = read_timeout
+        serial.verify_mode = OpenSSL::SSL::VERIFY_NONE if use_ssl && ssl_verify_none
+        serial.ssl_version = @ssl_version if @ssl_version
 
-        target_response = Net::HTTP.start(backend.host, backend.port, start_opts) do |http|
+        target_response = serial.start() do |http|
           http.request(target_request)
         end
       end

--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -33,7 +33,6 @@ class HttpStreamingResponseTest < Test::Unit::TestCase
       assert chunk.is_a?(String)
     end
 
-
   end
 
   def test_to_s

--- a/test/net_http_hacked_test.rb
+++ b/test/net_http_hacked_test.rb
@@ -6,11 +6,11 @@ class NetHttpHackedTest < Test::Unit::TestCase
   def test_net_http_hacked
     req = Net::HTTP::Get.new("/")
     http = Net::HTTP.start("www.iana.org", "80")
-    
+
     # Response code
     res = http.begin_request_hacked(req)
     assert res.code == "200"
-    
+
     # Headers
     headers = {}
     res.each_header { |k, v| headers[k] = v }
@@ -18,18 +18,18 @@ class NetHttpHackedTest < Test::Unit::TestCase
     assert headers.size > 0
     assert headers["content-type"] == "text/html; charset=UTF-8"
     assert !headers["date"].nil?
-    
+
     # Body
     chunks = []
     res.read_body do |chunk|
       chunks << chunk
     end
-    
+
     assert chunks.size > 0
     chunks.each do |chunk|
       assert chunk.is_a?(String)
     end
-    
+
     http.end_request_hacked
   end
   

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -42,8 +42,22 @@ class RackProxyTest < Test::Unit::TestCase
     assert_match(/(itunes|iphone|ipod|mac|ipad)/, last_response.body)
   end
 
+  def test_https_streaming_tls
+    app(:ssl_version => :TLSv1).host = 'www.apple.com'
+    get 'https://example.com'
+    assert last_response.ok?
+    assert_match(/(itunes|iphone|ipod|mac|ipad)/, last_response.body)
+  end
+
   def test_https_full_request
     app(:streaming => false).host = 'www.apple.com'
+    get 'https://example.com'
+    assert last_response.ok?
+    assert_match(/(itunes|iphone|ipod|mac|ipad)/, last_response.body)
+  end
+
+  def test_https_full_request_tls
+    app({:streaming => false, :ssl_version => :TLSv1}).host = 'www.apple.com'
     get 'https://example.com'
     assert last_response.ok?
     assert_match(/(itunes|iphone|ipod|mac|ipad)/, last_response.body)


### PR DESCRIPTION
Allow `Rack::Proxy` users to specify the exact version of SSL/TLS to use in the proxy.  Some web servers are configured to only accept certain versions which may cause SSL errors.

Two new tests were added to `test/rack_proxy_test.rb` that force `Rack::Proxy` to use `:TLSv1` instead of `:TLSv1_2` which is the default on my test machine.  Older versions of Ruby default to `:SSLv3` which can cause failures on servers that only allow for TLSv1+.

Attachment is a Wireshark dump showing the mix of both TLS v1 and v1.2 used in the tests.
![wireshark](https://cloud.githubusercontent.com/assets/13385275/15340480/56a2b490-1c4f-11e6-932e-003e36d401b3.png)
