### PR TITLE
Using Rack::Proxy as a middleware instead of using it as a standard Ruby class 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - gem install bundler
   - gem update bundler
+script: bundle exec rake test
 rvm:
   - 2.0.0
   - 2.1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+cache: bundler
+language: ruby
+before_install:
+  - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
+  - gem install bundler
+rvm:
+  - 2.0.0
+  - 2.1.5
+  - 2.2.2
+  - 2.2.3
+  - 2.3.0
+  - 2.3.1
+env:
+ - RAILS_ENV=test RACK_ENV=test
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: ruby
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - gem install bundler
+  - gem update bundler
 rvm:
   - 2.0.0
   - 2.1.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,13 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    power_assert (0.2.6)
     rack (1.2.1)
     rack-test (0.5.6)
       rack (>= 1.0)
     rake (0.9.2.2)
+    test-unit (3.1.5)
+      power_assert
 
 PLATFORMS
   ruby
@@ -19,3 +22,7 @@ DEPENDENCIES
   rack-proxy!
   rack-test
   rake
+  test-unit
+
+BUNDLED WITH
+   1.12.4

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-A request/response rewriting HTTP proxy. A Rack app.
-Subclass `Rack::Proxy` and provide your `rewrite_env` and `rewrite_response` methods.
+A request/response rewriting HTTP proxy. A Rack app. Subclass `Rack::Proxy` and provide your `rewrite_env` and `rewrite_response` methods.
 
-
-## Example
+Example
+-------
 
 ```ruby
 class Foo < Rack::Proxy
@@ -44,12 +43,54 @@ The same can be achieved for *all* requests going through the `Rack::Proxy` inst
 Rack::Proxy.new(ssl_verify_none: true)
 ```
 
+Using it as a middleware:
+-------------------------
+
+Example: Proxying only requests that end with ".php" could be done like this:
+
+```ruby
+require 'rack/proxy'
+class RackPhpProxy < Rack::Proxy
+
+  def perform_request(env)
+    request = Rack::Request.new(env)
+    if request.path =~ %r{\.php}
+      env["HTTP_HOST"] = "localhost"
+      env["REQUEST_PATH"] = "/php/#{request.fullpath}"
+      super(env)
+    else
+      @app.call(env)
+    end
+  end
+end
+```
+
+To use the middleware, please consider the following:
+
+1) For Rails we could add a configuration in config/application.rb
+
+```ruby
+  config.middleware.use RackPhpProxy, {ssl_verify_none: true}
+```
+
+2) For Sinatra or any Rack-based application:
+
+```ruby
+class MyAwesomeSinatra < Sinatra::Base
+   use  RackPhpProxy, {ssl_verify_none: true}
+end
+```
+
+This will allow to run the other requests through the application and only proxy the requests that match the condition from the middleware.
+
 See tests for more examples.
 
-## WARNING
+WARNING
+-------
 
 Doesn't work with fakeweb/webmock. Both libraries monkey-patch net/http code.
 
-## Todos
+Todos
+-----
 
-* Make the docs up to date with the current use case for this code: everything except streaming which involved a rather ugly monkey patch and only worked in 1.8, but does not work now.
+-	Make the docs up to date with the current use case for this code: everything except streaming which involved a rather ugly monkey patch and only worked in 1.8, but does not work now.

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -41,7 +41,7 @@ module Rack
     # @option opts [String, URI::HTTP] :backend Backend host to proxy requests to
     def initialize(app = nil, opts= {})
       @app = app
-      opts = app.is_a?(Hash) ? app : opts
+      opts = app.is_a?(Hash) ? app.merge(opts) : opts
       @streaming = opts.fetch(:streaming, true)
       @ssl_verify_none = opts.fetch(:ssl_verify_none, false)
       @backend = URI(opts[:backend]) if opts[:backend]

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -39,7 +39,8 @@ module Rack
     end
 
     # @option opts [String, URI::HTTP] :backend Backend host to proxy requests to
-    def initialize(opts = {})
+    def initialize(app = nil, opts= {})
+      @app = app
       @streaming = opts.fetch(:streaming, true)
       @ssl_verify_none = opts.fetch(:ssl_verify_none, false)
       @backend = URI(opts[:backend]) if opts[:backend]
@@ -105,6 +106,7 @@ module Rack
         http.read_timeout = read_timeout
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE if use_ssl && ssl_verify_none
         http.ssl_version = @ssl_version if @ssl_version
+        http.set_debug_output($stdout)
 
         target_response = http.start do
           http.request(target_request)

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -41,6 +41,7 @@ module Rack
     # @option opts [String, URI::HTTP] :backend Backend host to proxy requests to
     def initialize(app = nil, opts= {})
       @app = app
+      opts = app.is_a?(Hash) ? app : opts
       @streaming = opts.fetch(:streaming, true)
       @ssl_verify_none = opts.fetch(:ssl_verify_none, false)
       @backend = URI(opts[:backend]) if opts[:backend]
@@ -106,7 +107,6 @@ module Rack
         http.read_timeout = read_timeout
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE if use_ssl && ssl_verify_none
         http.ssl_version = @ssl_version if @ssl_version
-        http.set_debug_output($stdout)
 
         target_response = http.start do
           http.request(target_request)

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -40,8 +40,12 @@ module Rack
 
     # @option opts [String, URI::HTTP] :backend Backend host to proxy requests to
     def initialize(app = nil, opts= {})
-      @app = app
-      opts = app.is_a?(Hash) ? app.merge(opts) : opts
+      if app.is_a?(Hash)
+        opts = app
+        @app = nil
+      else
+        @app = app
+      end
       @streaming = opts.fetch(:streaming, true)
       @ssl_verify_none = opts.fetch(:ssl_verify_none, false)
       @backend = URI(opts[:backend]) if opts[:backend]

--- a/rack-proxy.gemspec
+++ b/rack-proxy.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency("rack")
   s.add_development_dependency("rack-test")
+  s.add_development_dependency("test-unit")
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
 require "rubygems"
+require 'bundler/setup'
+require 'bundler/gem_tasks'
 require "test/unit"
 
 require "rack"


### PR DESCRIPTION
In order for Rack Proxy to work as middleware for a Rack application (Rails or sinatra or any rack based application ) the initialize method for the Rack::Proxy class needed to be changed to receive first the application and then the options.


why is it useful?
Consider folowing scenario: Having a application that uses by default Savon for doing request to a web-service, but want to proxy only some requests to another server. could be easily achieved doing this:

```
require 'rack/proxy'
class RackPhpProxy < Rack::Proxy

  def perform_request(env)
    request = Rack::Request.new(env)
    if request.path =~ %r{\.php}
      env["HTTP_HOST"] = "localhost"
      env["REQUEST_PATH"] = "/php/#{request.fullpath}"
      super(env)
    else
      @app.call(env)
    end
  end
end

```

This means in Rails you could use this like this:
```
Rails.application.config.middleware.use RackPhpProxy, {ssl_verify_none: true}
```

and in sintra you could do like this:

```
class MyAwesomeSinatra < Sinatra::Base
   use  RackPhpProxy, {ssl_verify_none: true}
end
```
instead of doing
```
RackPhpProxy.new(ssl_verify_none: true)
```
In this example only requests that end with ".php" are proxied , the other requests are not proxied. 

This might be a backward incompatible change and the README might need updated too. I am opened though to suggestions.


This fixes also #53 

Let me know what you think. Thank you very much 

