### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 A request/response rewriting HTTP proxy. A Rack app. Subclass `Rack::Proxy` and provide your `rewrite_env` and `rewrite_response` methods.
 
+Installation
+-------
+
+Add the following to your Gemfile:
+
+```
+gem 'rack-proxy', '~> 0.6.0'
+```
+
+Or install:
+
+```
+gem install rack-proxy
+```
+
 Example
 -------
 

--- a/lib/net_http_hacked.rb
+++ b/lib/net_http_hacked.rb
@@ -1,5 +1,5 @@
 # We are hacking net/http to change semantics of streaming handling
-# from "block" semantics to regular "return" semnatics.
+# from "block" semantics to regular "return" semantics.
 # We need it to construct a streamable rack triplet:
 #
 # [status, headers, streamable_body]


### PR DESCRIPTION
Thanks for this project! Using it today to speed up a test suite.

This change adds installation instructions for the gem. It took me a moment to realize it was a gem, and I first searched for it on Rubygems with the wrong name. Putting the installation instructions in the README should simplify setup for new people.

The other change fixes a small typo, `semnatics` to `semantics`.
