### PR TITLE
remove Hop-by-hop Header Fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-proxy (0.5.18)
+    rack-proxy (0.6.0)
       rack
 
 GEM

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -121,6 +121,9 @@ module Rack
       body    = target_response.body || [""]
       body    = [body] unless body.respond_to?(:each)
 
+      # According to https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3.1Acc
+      # should remove hop-by-hop header fields
+      headers.reject! { |k| ['connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization', 'te', 'trailer', 'transfer-encoding', 'upgrade'].include? k.downcase }
       [target_response.code, headers, body]
     end
 

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -115,4 +115,10 @@ class RackProxyTest < Test::Unit::TestCase
       post "/", nil, "CONTENT_LENGTH" => nil
     end
   end
+
+  def test_response_header_included_Hop_by_hop
+    app({:streaming => true}).host = 'auth.goeasyship.com'
+    get 'https://example.com/oauth2/token/info?access_token=123'
+    assert !last_response.headers.key?('transfer-encoding')
+  end
 end


### PR DESCRIPTION
The problem I met just like this: https://github.com/ncr/rack-proxy/issues/50

I use `curl` to get data from website which will return `transfer-encoding`.  
I will see `curl: (56) Illegal or missing hexadecimal sequence in chunked-encoding`

According to [HTTP doc](https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3.1), we should remove `Hop-by-hop header` due to we are proxy. Right?
