### PR TITLE
properly close net::http session

### DIFF
--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -38,6 +38,7 @@ module Rack
       response.read_body(&block)
     ensure
       session.end_request_hacked
+      session.finish
     end
 
     def to_s


### PR DESCRIPTION
see discussion in this rack-reverse-proxy issue:

https://github.com/waterlink/rack-reverse-proxy/issues/41

possibly fixed #61

lmk if you think it should have a test