### PR TITLE
Remove spurious whitespace

### DIFF
--- a/lib/net_http_hacked.rb
+++ b/lib/net_http_hacked.rb
@@ -4,11 +4,11 @@
 #
 # [status, headers, streamable_body]
 #
-# See http://github.com/aniero/rack-streaming-proxy 
+# See http://github.com/aniero/rack-streaming-proxy
 # for alternative that uses additional process.
 #
 # BTW I don't like monkey patching either
-# but this is not real monkey patching. 
+# but this is not real monkey patching.
 # I just added some methods and named them very uniquely
 # to avoid eventual conflicts. You're safe. Trust me.
 #
@@ -45,7 +45,7 @@ class Net::HTTP
   #
   #   res
   # end
-  
+
   def begin_request_hacked(req)
     begin_transport req
     req.exec @socket, @curr_http_version, edit_path(req.path)
@@ -56,7 +56,7 @@ class Net::HTTP
     @req_hacked, @res_hacked = req, res
     @res_hacked
   end
-  
+
   def end_request_hacked
     @res_hacked.end_reading_body_hacked
     end_transport @req_hacked, @res_hacked
@@ -77,12 +77,12 @@ class Net::HTTPResponse
   #     @socket = nil
   #   end
   # end
-  
+
   def begin_reading_body_hacked(sock, reqmethodallowbody)
     @socket = sock
     @body_exist = reqmethodallowbody && self.class.body_permitted?
   end
-  
+
   def end_reading_body_hacked
     self.body
     @socket = nil


### PR DESCRIPTION
Might be overly pedantic, but I had occasion to step into the patched code and found some spurious whitespace.

This removes said whitespace.