### PR TITLE
Fix incorrect header serialization in streamed responses

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -117,7 +117,7 @@ module Rack
         end
       end
 
-      headers = (target_response.respond_to?(:headers) && target_response.headers) || self.class.normalize_headers(target_response.to_hash)
+      headers = self.class.normalize_headers(target_response.respond_to?(:headers) ? target_response.headers : target_response.to_hash)
       body    = target_response.body || [""]
       body    = [body] unless body.respond_to?(:each)
 


### PR DESCRIPTION
Fixes an incorrect header serialization in streamed responses (when
`@streaming` is true); the return value from
`HttpStreamingResponse.headers` consists of arrays of strings rather
than plain strings, which in turn causes Rack to fail.

Since `Rack::Proxy` already has a helper to normalize this, this change
ensures it always gets called.

This resolves issue #65 .