### PR TITLE
Updated the dependency on rack due to CVE-2018-16471

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: .
   specs:
     rack-proxy (0.6.5)
-      rack
+      rack (>= 2.0.6, < 2.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
     power_assert (0.2.6)
-    rack (2.0.3)
+    rack (2.0.7)
     rack-test (0.5.6)
       rack (>= 1.0)
     rake (0.9.2.2)
@@ -25,4 +25,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.16.0
+   2.0.1

--- a/rack-proxy.gemspec
+++ b/rack-proxy.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("rack")
+  s.add_dependency("rack", ">= 2.0.6", "< 2.1")
   s.add_development_dependency("rack-test")
   s.add_development_dependency("test-unit")
 end


### PR DESCRIPTION
We've noticed that the version of `rack` as locked in the `Gemfile.lock` was vulnerable to [CVE-2018-16471](https://nvd.nist.gov/vuln/detail/CVE-2018-16471).

This pull request locks it at `2.0.7` which is considered safe.