### PR TITLE
Remove deprecated option from gemspec

### DIFF
--- a/rack-proxy.gemspec
+++ b/rack-proxy.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{A request/response rewriting HTTP proxy. A Rack app.}
   s.description = %q{A Rack app that provides request/response rewriting proxy capabilities with streaming.}
 
-  s.rubyforge_project = "rack-proxy"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
This is deprecated by rubygems:

NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.