### PR TITLE
fix: preserve HTTP headers with periods

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -10,7 +10,7 @@ module Rack
     class << self
       def extract_http_request_headers(env)
         headers = env.reject do |k, v|
-          !(/^HTTP_[A-Z0-9_]+$/ === k) || v.nil?
+          !(/^HTTP_[A-Z0-9_\.]+$/ === k) || v.nil?
         end.map do |k, v|
           [reconstruct_header_name(k), v]
         end.inject(Utils::HeaderHash.new) do |hash, k_v|

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -89,12 +89,14 @@ class RackProxyTest < Test::Unit::TestCase
       'NOT-HTTP-HEADER' => 'test-value',
       'HTTP_ACCEPT' => 'text/html',
       'HTTP_CONNECTION' => nil,
-      'HTTP_CONTENT_MD5' => 'deadbeef'
+      'HTTP_CONTENT_MD5' => 'deadbeef',
+      'HTTP_HEADER.WITH.PERIODS' => 'stillmooing'
     }
 
     headers = proxy_class.extract_http_request_headers(env)
     assert headers.key?('ACCEPT')
     assert headers.key?('CONTENT-MD5')
+    assert headers.key?('HEADER.WITH.PERIODS')
     assert !headers.key?('CONNECTION')
     assert !headers.key?('NOT-HTTP-HEADER')
   end


### PR DESCRIPTION
Thank you to the maintainers of this gem! It is a critical part of some open source software that I maintain.

This PR allows headers with periods to be recognised as valid HTTP headers and preserved in the `extract_http_request_headers` method. According to https://tools.ietf.org/html/rfc7230#section-3.2.6 it is valid for a header to contain a period.
