### PR TITLE
Allow custom opts to be passed

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -51,6 +51,7 @@ module Rack
       @backend = URI(opts[:backend]) if opts[:backend]
       @read_timeout = opts.fetch(:read_timeout, 60)
       @ssl_version = opts[:ssl_version] if opts[:ssl_version]
+      @opts = opts
     end
 
     def call(env)


### PR DESCRIPTION
You never know what users might need, so it's better to give them freedom. Allows custom options to be passed inside the Proxy class, which can then be accessed later. (This PR was so simple that was made through Github's UI).