### PR TITLE
Set `false` to inherit of const_get

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -79,7 +79,7 @@ module Rack
         full_path = source_request.fullpath
       end
 
-      target_request = Net::HTTP.const_get(source_request.request_method.capitalize).new(full_path)
+      target_request = Net::HTTP.const_get(source_request.request_method.capitalize, false).new(full_path)
 
       # Setup headers
       target_request.initialize_http_header(self.class.extract_http_request_headers(source_request.env))


### PR DESCRIPTION
I set inherit to pass to const_get to `false` and restricted lookup just in case.
If there are no restrictions, you can specify a top-level class, so the client can craft the request to specify the `Tempfile` or` Logger` class.

```
# client
curl -X TEMPFILE http://127.0.0.1:9292/

# server log
2021-05-07 15:36:26 +0900 Rack app ("TEMPFILE /" - (127.0.0.1)): #<NoMethodError: undefined method `initialize_http_header' for #<Tempfile:0x00007fc1c597c8e8>>
```

Under ruby2.5, command injection is possible with `Logger.new("|date")`,
If specify `|` at the beginning of the request path, an error will occur, so it does not seem to be RCE.

```
$ telnet 127.0.0.1 9292
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
LOGGER |date HTTP/1.1
HTTP/1.1 400 Bad Request

Connection closed by foreign host.
```