### PR TITLE
Bump deps and fix tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     power_assert (0.2.6)
-    rack (2.0.3)
+    rack (2.2.3)
     rack-test (0.5.6)
       rack (>= 1.0)
-    rake (13.0.1)
+    rake (13.0.6)
     test-unit (3.1.5)
       power_assert
 

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -26,7 +26,7 @@ module Rack
 
       def normalize_headers(headers)
         mapped = headers.map do |k, v|
-          [k, if v.is_a? Array then v.join("\n") else v end]
+          [titleize(k), if v.is_a? Array then v.join("\n") else v end]
         end
         Utils::HeaderHash.new Hash[mapped]
       end
@@ -34,7 +34,11 @@ module Rack
       protected
 
       def reconstruct_header_name(name)
-        name.sub(/^HTTP_/, "").gsub("_", "-")
+        titleize(name.sub(/^HTTP_/, "").gsub("_", "-"))
+      end
+
+      def titleize(str)
+        str.split("-").map(&:capitalize).join("-")
       end
     end
 

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -49,12 +49,12 @@ module Rack
 
       @streaming = opts.fetch(:streaming, true)
       @ssl_verify_none = opts.fetch(:ssl_verify_none, false)
-      @backend = URI(opts[:backend]) if opts[:backend]
+      @backend = opts[:backend] ? URI(opts[:backend]) : nil
       @read_timeout = opts.fetch(:read_timeout, 60)
-      @ssl_version = opts[:ssl_version] if opts[:ssl_version]
+      @ssl_version = opts[:ssl_version]
 
-      @username = opts[:username] if opts[:username]
-      @password = opts[:password] if opts[:password]
+      @username = opts[:username]
+      @password = opts[:password]
 
       @opts = opts
     end

--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -1,6 +1,5 @@
 require "test_helper"
 require "rack/http_streaming_response"
-require "pry"
 
 class HttpStreamingResponseTest < Test::Unit::TestCase
 

--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -20,8 +20,8 @@ class HttpStreamingResponseTest < Test::Unit::TestCase
     assert headers.size.positive?
 
     assert_match %r{text/html; ?charset=utf-8}, headers["content-type"].first.downcase
-    assert_equal headers['content-type'], headers['CoNtEnT-TyPe']
-    assert headers['content-length'].first.to_i.positive?
+    assert_equal headers["content-type"], headers["CoNtEnT-TyPe"]
+    assert headers["content-length"].first.to_i.positive?
 
     # Body
     chunks = []

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -78,10 +78,10 @@ class RackProxyTest < Test::Unit::TestCase
     proxy_class = Rack::Proxy
 
     header = proxy_class.send(:reconstruct_header_name, "HTTP_ABC")
-    assert header == "ABC"
+    assert header == "Abc"
 
     header = proxy_class.send(:reconstruct_header_name, "HTTP_ABC_D")
-    assert header == "ABC-D"
+    assert header == "Abc-D"
   end
 
   def test_extract_http_request_headers

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -120,7 +120,7 @@ class RackProxyTest < Test::Unit::TestCase
   end
 
   def test_response_header_included_Hop_by_hop
-    app({:streaming => true}).host = 'auth.goeasyship.com'
+    app({:streaming => true}).host = 'mockapi.io'
     get 'https://example.com/oauth2/token/info?access_token=123'
     assert !last_response.headers.key?('transfer-encoding')
   end


### PR DESCRIPTION
Fixes #97 
Fixes #63 

- Bumped rack 2.0.3 → 2.2.3 - there are a lot of security fixes (see #97).
- Bumped rake 13.0.1 → 13.0.6 (see #97).
- Fixed some warnings for unitialized variables.
- There were some broken tests on `master` that I also fixed. They were referring to various domains, so I pointed them to a "neutral" one - mockapi.io. I have no affiliation with them.
- Changed assertion style in some tests to get better error messages. Eg: `assert x==y` → `assert_equal x, y`
- Changed header normalization to fix the issue with the `Set-Cookie` header. (See #63)
  HTTP headers are case insensitive, but [`Rack::MockResponse` is calling `headers.fetch`](https://github.com/rack/rack/blob/2.2.3/lib/rack/mock.rb#L235) which isn't case insensitive even when `headers` is a `Utils::HeaderHash` instance. The easiest solution seemed to be to just change our normalized header format to whatever `Rack::MockResponse` expects.