### PR TITLE
Remove HeaderHash warning

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -24,7 +24,7 @@ module Rack
           !(/^HTTP_[A-Z0-9_\.]+$/ === k) || v.nil?
         end.map do |k, v|
           [reconstruct_header_name(k), v]
-        end.inject(Utils::HeaderHash.new) do |hash, k_v|
+        end.inject(Headers.new) do |hash, k_v|
           k, v = k_v
           hash[k] = v
           hash
@@ -39,7 +39,7 @@ module Rack
         mapped = headers.map do |k, v|
           [titleize(k), if v.is_a? Array then v.join("\n") else v end]
         end
-        Utils::HeaderHash.new Hash[mapped]
+        Headers.new Hash[mapped]
       end
 
       protected


### PR DESCRIPTION
#107 
/home/sbstn/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rack-proxy-0.7.4/lib/rack/proxy.rb:27: warning: Rack::Utils::HeaderHash is deprecated and will be removed in Rack 3.1, switch to Rack::Headers