### PR TITLE
Add options for ssl/tls http connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Add some domain name like `debug.your_app.com` into your local `/etc/hosts` file
 Next start the proxy and your app. And now you can access to your Spring application through SSL connection via `https://debug.your_app.com` URI in a browser.
 
 ### Using SSL/TLS certificates with HTTP connection
-This may be helpful, for example, when third-party API has authentication by client TLS certificates and you need to proxy your requests and sign them with certificate. 
+This may be helpful, when third-party API has authentication by client TLS certificates and you need to proxy your requests and sign them with certificate. 
 
 Just specify Rack::Proxy SSL options and your request will use TLS HTTP connection:
 ```ruby

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ class TLSProxy < Rack::Proxy
   attr_accessor :original_request, :query_params
 
   def rewrite_env(env)
-    env["HTTP_HOST"] = "client-tls-auth-api:8443"
+    env["HTTP_HOST"] = "client-tls-auth-api.com:443"
     env
   end
 end

--- a/README.md
+++ b/README.md
@@ -311,13 +311,13 @@ key_raw = File.read('./certs/key.pem')
 cert = OpenSSL::X509::Certificate.new(cert_raw)
 key = OpenSSL::PKey.read(key_raw)
 
-use ForwardProxy, cert: cert, key: key, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_PEER, ssl_version: 'TLSv1_2'
+use TLSProxy, cert: cert, key: key, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_PEER, ssl_version: 'TLSv1_2'
 ```
 
 And rewrite host for example:
 ```ruby
-# forward_proxy.rb
-class ForwardProxy < Rack::Proxy
+# tls_proxy.rb
+class TLSProxy < Rack::Proxy
   attr_accessor :original_request, :query_params
 
   def rewrite_env(env)

--- a/README.md
+++ b/README.md
@@ -297,6 +297,35 @@ Add some domain name like `debug.your_app.com` into your local `/etc/hosts` file
 
 Next start the proxy and your app. And now you can access to your Spring application through SSL connection via `https://debug.your_app.com` URI in a browser.
 
+### Using SSL/TLS with HTTP connection
+This may be helpful, for example, when third-party API has authentication by client TLS certificates and you need to proxy your requests and sign them with certificate. 
+
+Just specify Rack::Proxy SSL options and tour request will use TLS HTTP connection:
+```ruby
+# config.ru
+. . .
+
+cert_raw = File.read('./certs/rootCA.crt')
+key_raw = File.read('./certs/key.pem')
+
+cert = OpenSSL::X509::Certificate.new(cert_raw)
+key = OpenSSL::PKey.read(key_raw)
+
+use ForwardProxy, cert: cert, key: key, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_PEER, ssl_version: 'TLSv1_2'
+```
+
+And rewrite host for example:
+```ruby
+# forward_proxy.rb
+class ForwardProxy < Rack::Proxy
+  attr_accessor :original_request, :query_params
+
+  def rewrite_env(env)
+    env["HTTP_HOST"] = "client-tls-auth-api:8443"
+    env
+  end
+end
+```
 
 WARNING
 ----

--- a/README.md
+++ b/README.md
@@ -297,10 +297,10 @@ Add some domain name like `debug.your_app.com` into your local `/etc/hosts` file
 
 Next start the proxy and your app. And now you can access to your Spring application through SSL connection via `https://debug.your_app.com` URI in a browser.
 
-### Using SSL/TLS with HTTP connection
+### Using SSL/TLS certificates with HTTP connection
 This may be helpful, for example, when third-party API has authentication by client TLS certificates and you need to proxy your requests and sign them with certificate. 
 
-Just specify Rack::Proxy SSL options and tour request will use TLS HTTP connection:
+Just specify Rack::Proxy SSL options and your request will use TLS HTTP connection:
 ```ruby
 # config.ru
 . . .

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -10,7 +10,7 @@ module Rack
       304 => true
     }.freeze
 
-    attr_accessor :use_ssl, :verify_mode, :read_timeout, :ssl_version
+    attr_accessor :use_ssl, :verify_mode, :read_timeout, :ssl_version, :cert, :key
 
     def initialize(request, host, port = nil)
       @request, @host, @port = request, host, port
@@ -60,7 +60,9 @@ module Rack
         http.use_ssl = use_ssl
         http.verify_mode = verify_mode
         http.read_timeout = read_timeout
-        http.ssl_version = ssl_version if use_ssl
+        http.ssl_version = ssl_version if ssl_version
+        http.cert = cert if cert
+        http.key = key if key
         http.start
       end
     end


### PR DESCRIPTION
This update allows you to use client TLS/SSL certificates with HTTP connection by just specifying Rack::Proxy SSL options and  requests to this proxy will use TLS HTTP connection. 
Feature may be helpful, for example, when third-party API has authentication by client TLS certificates and you need to proxy your requests and sign them with certificate. 

Example of use:

```ruby
# config.ru
. . .

cert_raw = File.read('./certs/rootCA.crt')
key_raw = File.read('./certs/key.pem')

cert = OpenSSL::X509::Certificate.new(cert_raw)
key = OpenSSL::PKey.read(key_raw)

use TLSProxy, cert: cert, key: key, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_PEER, ssl_version: 'TLSv1_2'
```

And rewrite host for example:
```ruby
# tls_proxy.rb
class TLSProxy < Rack::Proxy
  attr_accessor :original_request, :query_params

  def rewrite_env(env)
    env["HTTP_HOST"] = "client-tls-auth-api.com:443"
    env
  end
end
```