### PR TITLE
Use Rack::Headers if available

### DIFF
--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -29,9 +29,7 @@ module Rack
     alias_method :status, :code
 
     def headers
-      Utils::HeaderHash.new.tap do |h|
-        response.to_hash.each { |k, v| h[k] = v }
-      end
+      Rack::Proxy.build_header_hash(response.to_hash)
     end
 
     # Can be called only once!


### PR DESCRIPTION
This maintains compatibility with rack 2 while getting rid of warnings in rack 3 and preserves compatibility with future versions.

Closes #107 