### PR TITLE
Fix body and connection-error handling (#122, #123, #58)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
     rake (13.0.6)
     test-unit (3.6.1)
       power_assert
+    webrick (1.9.2)
 
 PLATFORMS
   arm64-darwin-22
@@ -24,6 +25,7 @@ DEPENDENCIES
   rack-test
   rake
   test-unit
+  webrick
 
 BUNDLED WITH
    2.4.17

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -130,33 +130,40 @@ module Rack
       read_timeout = env.delete('http.read_timeout') || @read_timeout
 
       # Create the response
-      if @streaming
-        # streaming response (the actual network communication is deferred, a.k.a. streamed)
-        target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port)
-        target_response.use_ssl = use_ssl
-        target_response.read_timeout = read_timeout
-        target_response.ssl_version = @ssl_version if @ssl_version
-        target_response.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_NONE) if use_ssl
-        target_response.cert = @cert if @cert
-        target_response.key = @key if @key
-      else
-        http = Net::HTTP.new(backend.host, backend.port)
-        http.use_ssl = use_ssl if use_ssl
-        http.read_timeout = read_timeout
-        http.ssl_version = @ssl_version if @ssl_version
-        http.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_NONE if use_ssl) if use_ssl
-        http.cert = @cert if @cert
-        http.key = @key if @key
+      begin
+        if @streaming
+          # streaming response (the actual network communication is deferred, a.k.a. streamed)
+          target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port)
+          target_response.use_ssl = use_ssl
+          target_response.read_timeout = read_timeout
+          target_response.ssl_version = @ssl_version if @ssl_version
+          target_response.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_NONE) if use_ssl
+          target_response.cert = @cert if @cert
+          target_response.key = @key if @key
+        else
+          http = Net::HTTP.new(backend.host, backend.port)
+          http.use_ssl = use_ssl if use_ssl
+          http.read_timeout = read_timeout
+          http.ssl_version = @ssl_version if @ssl_version
+          http.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_NONE if use_ssl) if use_ssl
+          http.cert = @cert if @cert
+          http.key = @key if @key
 
-        target_response = http.start do
-          http.request(target_request)
+          target_response = http.start do
+            http.request(target_request)
+          end
         end
+
+        code    = target_response.code
+        headers = self.class.normalize_headers(target_response.respond_to?(:headers) ? target_response.headers : target_response.to_hash)
+        body    = target_response.body || []
+        body    = [body] unless body.respond_to?(:each)
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ETIMEDOUT, Net::OpenTimeout, SocketError
+        return [502, {}, []]
       end
 
-      code    = target_response.code
-      headers = self.class.normalize_headers(target_response.respond_to?(:headers) ? target_response.headers : target_response.to_hash)
-      body    = target_response.body || [""]
-      body    = [body] unless body.respond_to?(:each)
+      # No entity body for status codes that don't allow one (1xx, 204, 304)
+      body = [] if Rack::Utils::STATUS_WITH_NO_ENTITY_BODY[code.to_i]
 
       # According to https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3.1Acc
       # should remove hop-by-hop header fields

--- a/rack-proxy.gemspec
+++ b/rack-proxy.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency("rack")
   s.add_development_dependency("rack-test")
   s.add_development_dependency("test-unit")
+  s.add_development_dependency("webrick")
 end

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -125,4 +125,89 @@ class RackProxyTest < Test::Unit::TestCase
     get 'https://example.com/oauth2/token/info?access_token=123'
     assert !last_response.headers.key?('transfer-encoding')
   end
+
+  # Issue #58: connection errors should return 502, not raise.
+  def test_connection_refused_returns_502
+    # Bind a socket to find a free port, then close it so connection is refused.
+    server = TCPServer.new('127.0.0.1', 0)
+    closed_port = server.addr[1]
+    server.close
+
+    app({:streaming => false}).host = "127.0.0.1:#{closed_port}"
+    get '/'
+    assert_equal 502, last_response.status
+    assert_equal '', last_response.body
+  end
+
+  def test_connection_refused_returns_502_streaming
+    server = TCPServer.new('127.0.0.1', 0)
+    closed_port = server.addr[1]
+    server.close
+
+    app({:streaming => true}).host = "127.0.0.1:#{closed_port}"
+    get '/'
+    assert_equal 502, last_response.status
+    assert_equal '', last_response.body
+  end
+
+  def test_unknown_host_returns_502
+    app({:streaming => false}).host = 'no-such-host.invalid'
+    get '/'
+    assert_equal 502, last_response.status
+  end
+
+  # Issues #122/#123: body should be [] for empty responses and for status
+  # codes that don't allow an entity body (1xx, 204, 304).
+  def test_no_entity_body_for_204
+    with_webrick_proxy(streaming: false) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get '/no-content'
+      assert_equal 204, last_response.status
+      assert_equal '', last_response.body
+    end
+  end
+
+  def test_no_entity_body_for_304
+    with_webrick_proxy(streaming: false) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get '/not-modified'
+      assert_equal 304, last_response.status
+      assert_equal '', last_response.body
+    end
+  end
+
+  def test_empty_body_is_not_array_with_empty_string
+    with_webrick_proxy(streaming: false) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get '/empty'
+      assert_equal 200, last_response.status
+      assert_equal '', last_response.body
+    end
+  end
+
+  private
+
+  # Spin up a tiny WEBrick server with fixed routes so we can exercise the
+  # proxy against real Net::HTTP requests without depending on a remote host.
+  def with_webrick_proxy(streaming:)
+    require 'webrick'
+    server = WEBrick::HTTPServer.new(
+      Port: 0,
+      BindAddress: '127.0.0.1',
+      Logger: WEBrick::Log.new(File::NULL),
+      AccessLog: []
+    )
+    server.mount_proc('/no-content')   { |_req, res| res.status = 204 }
+    server.mount_proc('/not-modified') { |_req, res| res.status = 304 }
+    server.mount_proc('/empty')        { |_req, res| res.body = '' }
+    Thread.new { server.start }
+    port = server.config[:Port]
+
+    proxy = HostProxy.new(streaming: streaming)
+    @app = proxy
+    yield port, proxy
+  ensure
+    server&.shutdown
+    @app = nil
+  end
 end


### PR DESCRIPTION
## Summary

Tier 1 bugfixes from the issue triage. All three are small, behavior-correcting fixes with no API changes.

- **#122** Body is now `[]` instead of `[""]` when upstream returns no body. Rack 3's lint complains about `[""]` for empty bodies.
- **#123** Body is forced to `[]` for status codes that don't allow an entity body (1xx, 204, 304). Uses `Rack::Utils::STATUS_WITH_NO_ENTITY_BODY` so the list stays correct as Rack evolves.
- **#58** Connection failures (`Errno::ECONNREFUSED`, `Errno::EHOSTUNREACH`, `Errno::ENETUNREACH`, `Errno::ETIMEDOUT`, `Net::OpenTimeout`, `SocketError`) now return `[502, {}, []]` instead of raising — the proxy can't reach the backend, which is what 502 Bad Gateway means.

Also closes **#103** (rack version bump — already shipped in v0.7.8).

## Test plan

- [x] All existing tests still pass (17 unchanged)
- [x] New tests use a local WEBrick server so they're deterministic (no remote-host flakiness)
- [x] Connection-refused tests bind a socket to get a free port, close it, then proxy to that port — guaranteed refused, no race
- [x] End-to-end smoke test: ran rack-proxy mounted in a real WEBrick HTTP server pointing at a closed backend port; an external HTTP client (Net::HTTP) receives `HTTP/1.1 502` with empty body and `content-length: 0`, in both streaming and non-streaming modes.

Closes #122
Closes #123
Closes #58
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)