### PR TITLE
Add :logger option for Net::HTTP debug output (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Options can be set when initializing the middleware or overriding a method.
 * `:ssl_version` - tell `Net::HTTP` to set a specific `ssl_version`
 * `:backend` - the URI parseable format of host and port of the target proxy backend. If not set it will assume the backend target is the same as the source.
 * `:read_timeout` - set proxy timeout it defaults to 60 seconds
+* `:logger` - any object responding to `#<<` (e.g. `$stdout`, a `StringIO`, or a Ruby `Logger`). Wired through to `Net::HTTP#set_debug_output` so the full HTTP wire-level conversation is written to the sink. Useful for debugging.
 
 To pass in options, when you configure your middleware you can pass them in as an optional hash.
 

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -10,7 +10,7 @@ module Rack
       304 => true
     }.freeze
 
-    attr_accessor :use_ssl, :verify_mode, :read_timeout, :ssl_version, :cert, :key
+    attr_accessor :use_ssl, :verify_mode, :read_timeout, :ssl_version, :cert, :key, :logger
 
     def initialize(request, host, port = nil)
       @request, @host, @port = request, host, port
@@ -61,6 +61,7 @@ module Rack
         http.ssl_version = ssl_version if ssl_version
         http.cert = cert if cert
         http.key = key if key
+        http.set_debug_output(logger) if logger
         http.start
       end
     end

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -83,6 +83,10 @@ module Rack
       @username = opts[:username]
       @password = opts[:password]
 
+      # Optional logger for Net::HTTP debug output. Accepts anything with a #<< method
+      # (e.g. $stdout, a StringIO, or a Ruby Logger instance).
+      @logger = opts[:logger]
+
       @opts = opts
     end
 
@@ -143,6 +147,7 @@ module Rack
           target_response.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_PEER) if use_ssl
           target_response.cert = @cert if @cert
           target_response.key = @key if @key
+          target_response.logger = @logger if @logger
         else
           http = Net::HTTP.new(backend.host, backend.port)
           http.use_ssl = use_ssl if use_ssl
@@ -151,6 +156,7 @@ module Rack
           http.verify_mode = @verify_mode || OpenSSL::SSL::VERIFY_PEER if use_ssl
           http.cert = @cert if @cert
           http.key = @key if @key
+          http.set_debug_output(@logger) if @logger
 
           target_response = http.start do
             http.request(target_request)

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -226,6 +226,41 @@ class RackProxyTest < Test::Unit::TestCase
     assert last_response.ok?
   end
 
+  # Issue #80: a :logger option should pipe Net::HTTP debug output to the
+  # given sink (anything responding to #<<). We use a StringIO to capture it.
+  def test_logger_captures_request_in_non_streaming
+    sink = StringIO.new
+    with_webrick_proxy(streaming: false, logger: sink) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get '/empty'
+      assert last_response.ok?
+    end
+    assert_match(/GET \/empty/, sink.string,
+      "expected debug output to include request line, got: #{sink.string.inspect}")
+  end
+
+  def test_logger_captures_request_in_streaming
+    sink = StringIO.new
+    with_webrick_proxy(streaming: true, logger: sink) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get '/empty'
+      assert last_response.ok?
+    end
+    assert_match(/GET \/empty/, sink.string,
+      "expected debug output to include request line, got: #{sink.string.inspect}")
+  end
+
+  def test_no_logger_means_no_debug_output
+    # Without a :logger option, Net::HTTP's set_debug_output should never be
+    # called. We can't directly assert that, but we can confirm requests still
+    # work when no logger is configured (covered by every other test).
+    with_webrick_proxy(streaming: false) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get '/empty'
+      assert last_response.ok?
+    end
+  end
+
   private
 
   def assert_no_array_header_values(streaming:)
@@ -242,7 +277,7 @@ class RackProxyTest < Test::Unit::TestCase
 
   # Spin up a tiny WEBrick server with fixed routes so we can exercise the
   # proxy against real Net::HTTP requests without depending on a remote host.
-  def with_webrick_proxy(streaming:)
+  def with_webrick_proxy(**proxy_opts)
     require 'webrick'
     server = WEBrick::HTTPServer.new(
       Port: 0,
@@ -260,7 +295,7 @@ class RackProxyTest < Test::Unit::TestCase
     Thread.new { server.start }
     port = server.config[:Port]
 
-    proxy = HostProxy.new(streaming: streaming)
+    proxy = HostProxy.new(**proxy_opts)
     @app = proxy
     yield port, proxy
   ensure


### PR DESCRIPTION
## Summary

Closes #80. Adds a `:logger` constructor option that wires through to `Net::HTTP#set_debug_output`, exposing the full wire-level HTTP conversation to a sink of the caller's choice.

The sink can be anything with a `#<<` method:

```ruby
Rack::Proxy.new(logger: $stdout)
Rack::Proxy.new(logger: Logger.new('proxy.log'))
Rack::Proxy.new(logger: StringIO.new)   # useful in tests
```

Plumbed through both streaming and non-streaming paths:
- Non-streaming: `http.set_debug_output(@logger)` directly on the `Net::HTTP` instance
- Streaming: `target_response.logger = @logger` on `HttpStreamingResponse`, which forwards into `Net::HTTP#set_debug_output` in `#session`

## Test plan

- [x] 3 new tests (33 total, 0 failures)
- [x] Verified that the captured `StringIO` contains the request line (`GET /empty`) for both streaming modes
- [x] Verified that omitting `:logger` leaves everything unchanged

This is additive and non-breaking — safe to release as 0.8.1.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)