### PR TITLE
Fix: Handle non-rewindable body streams in Rack::Proxy

### DIFF
--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -5,7 +5,7 @@ module Rack
 
   # Subclass and bring your own #rewrite_request and #rewrite_response
   class Proxy
-    VERSION = "0.8.2".freeze
+    VERSION = "0.8.3".freeze
 
     HOP_BY_HOP_HEADERS = {
       'connection' => true,

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -128,7 +128,7 @@ module Rack
         target_request.body_stream    = source_request.body
         target_request.content_length = source_request.content_length.to_i
         target_request.content_type   = source_request.content_type if source_request.content_type
-        target_request.body_stream.rewind
+        target_request.body_stream.rewind if target_request.body_stream.respond_to?(:rewind)
       end
 
       # Use basic auth if we have to

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -120,6 +120,42 @@ class RackProxyTest < Test::Unit::TestCase
     end
   end
 
+  # An input stream that deliberately omits #rewind, mimicking
+  # Rackup::Handler::WEBrick::Input under Rack 3 (the Rack 3 SPEC no longer
+  # requires the input stream to respond to #rewind, only gets/each/read).
+  class NonRewindableInput
+    def initialize(string)
+      @io = StringIO.new(string)
+    end
+
+    def read(*args) = @io.read(*args)
+    def gets(*args) = @io.gets(*args)
+    def each(&block) = @io.each(&block)
+    # intentionally NO #rewind
+  end
+
+  # Issue #128: a non-rewindable body stream must not raise (it used to blow up
+  # with NoMethodError on #rewind, surfacing confusingly as a 500). The body
+  # must still be forwarded intact, since it is never read before Net::HTTP sends it.
+  def test_non_rewindable_body_is_forwarded_without_raising
+    with_webrick_proxy(streaming: false) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+
+      body = NonRewindableInput.new("hello=world")
+      assert !body.respond_to?(:rewind), "fixture must not be rewindable to exercise the guard"
+
+      env = Rack::MockRequest.env_for("/echo-body", method: "POST")
+      env["rack.input"]     = body
+      env["CONTENT_LENGTH"] = "hello=world".bytesize.to_s
+      env["CONTENT_TYPE"]   = "text/plain"
+
+      status, _headers, response = nil
+      assert_nothing_raised { status, _headers, response = proxy.call(env) }
+      assert_equal 200, status.to_i
+      assert_equal "hello=world", response.to_a.join, "body must be forwarded intact"
+    end
+  end
+
   def test_response_header_included_Hop_by_hop
     app({:streaming => true}).host = 'mockapi.io'
     get 'https://example.com/oauth2/token/info?access_token=123'
@@ -308,6 +344,7 @@ class RackProxyTest < Test::Unit::TestCase
       res['x-custom'] = 'value-here'
       res.body = 'ok'
     end
+    server.mount_proc('/echo-body')    { |req, res| res.body = req.body.to_s }
     Thread.new { server.start }
     port = server.config[:Port]
 


### PR DESCRIPTION
Handle non-rewindable body streams in Rack::Proxy

Rackup::Handler::WEBrick::Input does not implement rewind under Pact 2 / Rack 3 / Rails 8

The `rewind` method is called on the `body_stream` of the `target_request`. This body_stream is the soource_request.body, which may or may not implement that method. In my case using Pact 2.0.1 (and Rack 3 / Rails 8) the request body is a `Rackup::Handler::WEBrick::Input` which has no `rewind` method.

This therefore leads to an error when trying to rewind a non-rewindable body stream.

```
NoMethodError: undefined method 'rewind' for an instance of Rackup::Handler::WEBrick::Input
```

This error then, confusingly, manifests as a 500 Internal Server Error from Pact.

```
ERROR ThreadId(11) pact_verifier: No pacts found for provider 'blah' matching the given consumer version selectors in pact broker 'http://127.0.0.1:9002': IO Error - Request to pact broker path 'blah' failed: 500 Internal Server Error. URL: 'http://127.0.0.1:9002'
```
nb: the `http://127.0.0.1:9002` is the default proxy server from pact, spun up by rack-proxy.