### PR TITLE
Batch 2: P0 security hardening of the proxy data path

### DIFF
--- a/MODERNIZATION_PLAN.md
+++ b/MODERNIZATION_PLAN.md
@@ -1,5 +1,10 @@
 # rack-proxy — 2026 Modernization + Hardening Roadmap
 
+> **Progress:** Batch 1 (green loop) — DONE on branch `modernization/batch-1-green-loop`.
+> Batch 2 (all six P0 security fixes + P1-4 config dedup) — DONE on branch
+> `modernization/batch-2-security`, each with a regression test on the offline harness.
+> Remaining: Batch 3 (modernization & hardening) and Batch 4 (docs, supply-chain, polish).
+
 Baseline already in place (do **not** redo): VERIFY_PEER default (proxy.rb:149/158), 502-on-connect-error mapping (proxy.rb:172), Rack 3 `Headers`/Rack 2 `HeaderHash` branch (proxy.rb:44-50), non-rewindable body guard (proxy.rb:131), `:logger` option. Everything below builds on that.
 
 Effort key: **S** ≤ ½ day · **M** ~1-2 days · **L** ~several days. `[agent-DX]` = directly serves the goal of a repo that is easy + safe for AI agents to work in.

--- a/lib/net_http_hacked.rb
+++ b/lib/net_http_hacked.rb
@@ -49,9 +49,12 @@ class Net::HTTP
   def begin_request_hacked(req)
     begin_transport req
     req.exec @socket, @curr_http_version, edit_path(req.path)
+    # Skip ALL 1xx interim responses (100 Continue, 103 Early Hints, etc.), not
+    # just 100 Continue, to reach the final response — matching modern net/http.
+    # Otherwise a backend's 103 Early Hints is mistaken for the final response.
     begin
       res = Net::HTTPResponse.read_new(@socket)
-    end while res.kind_of?(Net::HTTPContinue)
+    end while res.kind_of?(Net::HTTPInformation)
     res.begin_reading_body_hacked(@socket, req.response_body_permitted?)
     @req_hacked, @res_hacked = req, res
     @res_hacked

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -37,12 +37,25 @@ module Rack
       return if connection_closed
 
       response.read_body(&block)
+    rescue StandardError => e
+      # The status/headers are already on the wire, so we can't turn a mid-stream
+      # backend failure into a 502. Log it and re-raise so the server aborts the
+      # transfer (the client sees a truncated response, not a false "complete").
+      logger << "rack-proxy: streaming backend read failed: #{e.class}: #{e.message}\n" if logger.respond_to?(:<<)
+      raise
     ensure
       close_connection
     end
 
     def to_s
       @to_s ||= StringIO.new.tap { |io| each { |line| io << line } }.string
+    end
+
+    # Rack calls #close on the response body when it is done with it, including
+    # when it bails out early (HEAD, 304, a client disconnect). Without this, a
+    # body that is never iterated leaks the backend TCP/TLS connection until GC.
+    def close
+      close_connection
     end
 
     protected
@@ -72,12 +85,22 @@ module Rack
 
     attr_accessor :connection_closed
 
+    # Idempotent, best-effort teardown. Uses @session directly (never the lazy
+    # #session accessor) so closing a response whose body was never read does not
+    # open a connection just to tear it down. Swallows teardown errors: a
+    # half-read or already-reset backend must not crash the app or mask the
+    # original error.
     def close_connection
-      return if connection_closed
+      return if connection_closed || @session.nil?
 
-      session.end_request_hacked
-      session.finish
       self.connection_closed = true
+      begin
+        @session.end_request_hacked
+      ensure
+        @session.finish if @session.started?
+      end
+    rescue StandardError
+      # best-effort: the connection may already be gone
     end
   end
 end

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -17,6 +17,20 @@ module Rack
       'upgrade' => true
     }.freeze
 
+    # Backend/network failures that must surface as 502 Bad Gateway rather than
+    # crashing the proxy with a raw 500. Construction- and policy-time failures
+    # are mapped separately (400/501/502) in #perform_request.
+    BACKEND_ERRORS = [
+      Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ECONNABORTED,
+      Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ETIMEDOUT, Errno::EPIPE,
+      SocketError,
+      Timeout::Error,               # includes Net::OpenTimeout
+      Net::ReadTimeout, Net::WriteTimeout,
+      IOError,                      # includes EOFError
+      OpenSSL::SSL::SSLError,
+      Net::ProtocolError            # includes Net::HTTPBadResponse
+    ].freeze
+
     class << self
       def extract_http_request_headers(env)
         headers = env.reject do |k, v|
@@ -24,6 +38,17 @@ module Rack
         end.map do |k, v|
           [reconstruct_header_name(k), v]
         end.then { |pairs| build_header_hash(pairs) }
+
+        # Strip hop-by-hop headers before forwarding. Relaying the client's
+        # Connection / TE / Transfer-Encoding (etc.) enables request smuggling
+        # and confuses the backend — these are connection-scoped, not end-to-end.
+        # Per RFC 7230 §6.1 any field named in the inbound Connection header is
+        # itself hop-by-hop for this hop. Use #delete (not #reject!) so the
+        # returned HeaderHash's case-insensitive index stays consistent on Rack 2.
+        connection_named = headers['Connection'].to_s.downcase.split(/,\s*/).map(&:strip)
+        headers.keys.each do |key|
+          headers.delete(key) if HOP_BY_HOP_HEADERS[key.downcase] || connection_named.include?(key.downcase)
+        end
 
         x_forwarded_for = (headers['X-Forwarded-For'].to_s.split(/, +/) << env['REMOTE_ADDR']).join(', ')
 
@@ -105,58 +130,72 @@ module Rack
       triplet
     end
 
+    # SSRF guardrail. Override to restrict which backends this proxy may connect
+    # to; `backend` responds to #host, #port and #scheme. Return false to refuse,
+    # which makes the proxy respond 502. The default allows any backend for
+    # backward compatibility — but when no :backend is configured the destination
+    # is derived from the client-controlled Host header, so a subclass in that
+    # setup SHOULD override this to allowlist expected hosts (or set a fixed
+    # :backend). See the README "Security considerations".
+    def backend_allowed?(backend)
+      true
+    end
+
     protected
 
     def perform_request(env)
       source_request = Rack::Request.new(env)
 
-      # Initialize request
-      if source_request.fullpath == ""
-        full_path = URI.parse(env['REQUEST_URI']).request_uri
-      else
-        full_path = source_request.fullpath
-      end
-
-      target_request = Net::HTTP.const_get(source_request.request_method.capitalize, false).new(full_path)
-
-      # Setup headers
-      target_request.initialize_http_header(self.class.extract_http_request_headers(source_request.env))
-
-      # Setup body
-      if target_request.request_body_permitted? && source_request.body
-        target_request.body_stream    = source_request.body
-        target_request.content_length = source_request.content_length.to_i
-        target_request.content_type   = source_request.content_type if source_request.content_type
-        target_request.body_stream.rewind if target_request.body_stream.respond_to?(:rewind)
-      end
-
-      # Use basic auth if we have to
-      target_request.basic_auth(@username, @password) if @username && @password
-
-      backend = env.delete('rack.backend') || @backend || source_request
-      use_ssl = backend.scheme == "https" || @cert
-      read_timeout = env.delete('http.read_timeout') || @read_timeout
-
-      # Create the response
+      # Everything that can fail on a hostile/unreachable request or backend is
+      # mapped to a status code here so the proxy never surfaces a raw 500:
+      #   400 malformed request URI, 501 unknown method, 502 backend failure.
       begin
+        # Initialize request
+        if source_request.fullpath == ""
+          full_path = URI.parse(env['REQUEST_URI']).request_uri
+        else
+          full_path = source_request.fullpath
+        end
+
+        request_class = net_http_request_class(source_request.request_method)
+        return [501, {}, []] if request_class.nil?
+
+        target_request = request_class.new(full_path)
+
+        # Setup headers
+        target_request.initialize_http_header(self.class.extract_http_request_headers(source_request.env))
+
+        # Forward the backend response verbatim: don't let Net::HTTP transparently
+        # gzip-decode it, which would leave the forwarded Content-Length describing
+        # the compressed size (a body/Content-Length desync). The client decodes
+        # its own content-encoding.
+        target_request.instance_variable_set(:@decode_content, false) if target_request.instance_variable_defined?(:@decode_content)
+
+        # Setup body
+        if target_request.request_body_permitted? && source_request.body
+          target_request.body_stream    = source_request.body
+          target_request.content_length = source_request.content_length.to_i
+          target_request.content_type   = source_request.content_type if source_request.content_type
+          target_request.body_stream.rewind if target_request.body_stream.respond_to?(:rewind)
+        end
+
+        # Use basic auth if we have to
+        target_request.basic_auth(@username, @password) if @username && @password
+
+        backend = env.delete('rack.backend') || @backend || source_request
+        return [502, {}, []] unless backend_allowed?(backend)
+
+        use_ssl = backend.scheme == "https" || @cert
+        read_timeout = env.delete('http.read_timeout') || @read_timeout
+
         if @streaming
           # streaming response (the actual network communication is deferred, a.k.a. streamed)
           target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port)
-          target_response.use_ssl = use_ssl
-          target_response.read_timeout = read_timeout
-          target_response.ssl_version = @ssl_version if @ssl_version
-          target_response.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_PEER) if use_ssl
-          target_response.cert = @cert if @cert
-          target_response.key = @key if @key
+          configure_backend_connection(target_response, use_ssl: use_ssl, read_timeout: read_timeout)
           target_response.logger = @logger if @logger
         else
           http = Net::HTTP.new(backend.host, backend.port)
-          http.use_ssl = use_ssl if use_ssl
-          http.read_timeout = read_timeout
-          http.ssl_version = @ssl_version if @ssl_version
-          http.verify_mode = @verify_mode || OpenSSL::SSL::VERIFY_PEER if use_ssl
-          http.cert = @cert if @cert
-          http.key = @key if @key
+          configure_backend_connection(http, use_ssl: use_ssl, read_timeout: read_timeout)
           http.set_debug_output(@logger) if @logger
 
           target_response = http.start do
@@ -168,18 +207,45 @@ module Rack
         headers = self.class.normalize_headers(target_response.respond_to?(:headers) ? target_response.headers : target_response.to_hash)
         body    = target_response.body || []
         body    = [body] unless body.respond_to?(:each)
-      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ETIMEDOUT, Net::OpenTimeout, SocketError
+      rescue URI::InvalidURIError
+        return [400, {}, []]
+      rescue *BACKEND_ERRORS => e
+        @logger << "rack-proxy: backend request failed: #{e.class}: #{e.message}\n" if @logger.respond_to?(:<<)
         return [502, {}, []]
       end
 
       # No entity body for status codes that don't allow one (1xx, 204, 304)
       body = [] if Rack::Utils::STATUS_WITH_NO_ENTITY_BODY[code.to_i]
 
-      # According to https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3.1Acc
-      # should remove hop-by-hop header fields
-      headers.reject! { |k| HOP_BY_HOP_HEADERS[k.downcase] }
+      # Remove hop-by-hop header fields from the response. Use #delete (not
+      # #reject!) so the returned HeaderHash's case-insensitive index stays
+      # consistent on Rack 2 for any downstream middleware.
+      headers.keys.each { |k| headers.delete(k) if HOP_BY_HOP_HEADERS[k.downcase] }
 
       [code, headers, body]
+    end
+
+    private
+
+    # Resolve the Net::HTTP request class for an HTTP method, or nil if there is
+    # no matching Net::HTTP::<Verb> (unknown/unsupported method -> 501).
+    def net_http_request_class(method)
+      Net::HTTP.const_get(method.capitalize, false)
+    rescue NameError
+      nil
+    end
+
+    # Single source of truth for TLS/timeout setup, applied identically to both
+    # the streaming response and the non-streaming Net::HTTP connection so a TLS
+    # option (notably the VERIFY_PEER default) can never land on only one path.
+    def configure_backend_connection(conn, use_ssl:, read_timeout:)
+      conn.use_ssl = use_ssl
+      conn.read_timeout = read_timeout
+      conn.ssl_version = @ssl_version if @ssl_version
+      conn.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_PEER) if use_ssl
+      conn.cert = @cert if @cert
+      conn.key = @key if @key
+      conn
     end
   end
 end

--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -52,4 +52,29 @@ class HttpStreamingResponseTest < Test::Unit::TestCase
     assert_equal body.to_s, body.to_s
   end
 
+  # P0-1: Rack servers call body.close; it must be public.
+  def test_body_responds_to_close
+    assert @response.body.respond_to?(:close)
+  end
+
+  # P0-1: closing a response whose body was never read must NOT dial the backend
+  # just to tear it down (i.e. it must not trigger the lazy session).
+  def test_close_without_reading_opens_no_connection
+    req = Net::HTTP::Get.new("/")
+    response = Rack::HttpStreamingResponse.new(req, "127.0.0.1", @server.config[:Port])
+    response.use_ssl = false
+    assert_nothing_raised { response.close }
+    assert_nil response.instance_variable_get(:@session), "close must not open a session"
+  end
+
+  # P0-1: after streaming, the backend connection must be finished, and close
+  # must be idempotent.
+  def test_close_releases_connection_after_reading
+    @response.body.each { |_chunk| }
+    session = @response.instance_variable_get(:@session)
+    assert_not_nil session
+    assert !session.started?, "backend connection must be finished after streaming"
+    assert_nothing_raised { @response.close }
+  end
+
 end

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -285,12 +285,30 @@ class RackProxyTest < Test::Unit::TestCase
 
   # The local HTTPS server uses a self-signed cert, so the default VERIFY_PEER
   # must reject it. This is the hermetic replacement for the old badssl.com test
-  # and is now the primary regression guard for the VERIFY_PEER default.
+  # and is now the primary regression guard for the VERIFY_PEER default. Since
+  # Batch 2 maps backend failures to 502 (rather than raising), we assert 502 and
+  # use the logger to confirm the cause is specifically a TLS verification error.
   def test_https_default_rejects_invalid_certificate
-    with_webrick_proxy(ssl: true, streaming: false) do |port, proxy|
+    sink = StringIO.new
+    with_webrick_proxy(ssl: true, streaming: false, logger: sink) do |port, proxy|
       proxy.host = "127.0.0.1:#{port}"
-      error = assert_raise(OpenSSL::SSL::SSLError) { get 'https://example.com/' }
-      assert_match(/certificate verify failed/, error.message)
+      get 'https://example.com/'
+      assert_equal 502, last_response.status,
+        'a backend cert failing VERIFY_PEER must become 502, not a raised 500'
+      assert_match(/SSLError|certificate verify failed/, sink.string,
+        "expected the 502 to be caused by a TLS verification failure, got: #{sink.string.inspect}")
+    end
+  end
+
+  # Same guard for the default (streaming) path, which previously had no
+  # VERIFY_PEER coverage at all (P1-4 deduped the TLS config into one place).
+  def test_https_default_rejects_invalid_certificate_streaming
+    sink = StringIO.new
+    with_webrick_proxy(ssl: true, streaming: true, logger: sink) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get 'https://example.com/'
+      assert_equal 502, last_response.status
+      assert_match(/SSLError|certificate verify failed/, sink.string)
     end
   end
 
@@ -353,7 +371,125 @@ class RackProxyTest < Test::Unit::TestCase
     end
   end
 
+  # P0-2: hop-by-hop headers (and any header named by Connection) must be
+  # stripped from the FORWARDED REQUEST, closing the CL/TE smuggling surface.
+  def test_request_hop_by_hop_headers_are_stripped
+    env = {
+      'REMOTE_ADDR'            => '10.0.0.1',
+      'HTTP_ACCEPT'            => 'text/html',
+      'HTTP_CONNECTION'        => 'keep-alive, X-Purge-Me',
+      'HTTP_KEEP_ALIVE'        => 'timeout=5',
+      'HTTP_TE'                => 'trailers',
+      'HTTP_TRANSFER_ENCODING' => 'chunked',
+      'HTTP_PROXY_AUTHORIZATION' => 'Basic zzz',
+      'HTTP_UPGRADE'           => 'websocket',
+      'HTTP_X_PURGE_ME'        => 'please',
+      'HTTP_AUTHORIZATION'     => 'Bearer keep-me'
+    }
+    headers = Rack::Proxy.extract_http_request_headers(env)
+
+    %w[Connection Keep-Alive Te Transfer-Encoding Proxy-Authorization Upgrade].each do |h|
+      assert !headers.key?(h), "#{h} is hop-by-hop and must not be forwarded"
+    end
+    assert !headers.key?('X-Purge-Me'), 'a header named in Connection must be dropped'
+    assert_equal 'text/html', headers['Accept'], 'end-to-end headers must survive'
+    assert_equal 'Bearer keep-me', headers['Authorization'], 'end-to-end Authorization must survive'
+  end
+
+  # P0-6: a gzip-encoded backend body must be forwarded verbatim (still
+  # compressed, Content-Encoding intact, Content-Length matching the bytes sent),
+  # not transparently inflated (which desyncs Content-Length).
+  def test_gzip_body_is_forwarded_verbatim_non_streaming
+    assert_gzip_forwarded_verbatim(streaming: false)
+  end
+
+  def test_gzip_body_is_forwarded_verbatim_streaming
+    assert_gzip_forwarded_verbatim(streaming: true)
+  end
+
+  # P0-3: a method with no Net::HTTP::<Verb> class must be 501, not a raised 500.
+  # (Net::HTTP does define WebDAV verbs like PROPFIND, so use a truly unknown one.)
+  def test_unknown_method_returns_501
+    with_webrick_proxy(streaming: false) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      env = Rack::MockRequest.env_for("/", method: "GET")
+      env["REQUEST_METHOD"] = "BOGUSVERB"
+      status, _headers, _body = proxy.call(env)
+      assert_equal 501, status
+    end
+  end
+
+  # P0-4: a backend refused by backend_allowed? must 502 even when the backend
+  # is reachable and would otherwise succeed.
+  def test_disallowed_backend_returns_502
+    with_webrick_proxy(streaming: false) do |port, proxy|
+      def proxy.backend_allowed?(_backend); false; end
+      proxy.host = "127.0.0.1:#{port}"
+      get "/"
+      assert_equal 502, last_response.status
+    end
+  end
+
+  def test_backend_allowed_by_default
+    proxy = Rack::Proxy.new
+    assert proxy.send(:backend_allowed?, URI("http://198.51.100.7:80")),
+      'default must allow any backend for backward compatibility'
+  end
+
+  # P0-5: an interim 103 Early Hints from the backend must be skipped so the
+  # final 200 (and its body) is returned, on the default streaming path.
+  def test_early_hints_103_is_skipped_streaming
+    with_early_hints_backend do |port|
+      proxy = HostProxy.new(streaming: true)
+      @app = proxy
+      proxy.host = "127.0.0.1:#{port}"
+      get "/"
+      assert_equal 200, last_response.status.to_i, 'must return the final 200, not the interim 103'
+      assert_equal 'hello world', last_response.body
+    end
+  ensure
+    @app = nil
+  end
+
   private
+
+  def assert_gzip_forwarded_verbatim(streaming:)
+    with_webrick_proxy(streaming: streaming) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get "/gzip"
+      assert last_response.ok?
+      body = last_response.body
+      assert_equal 'gzip', last_response['content-encoding'], 'Content-Encoding must be preserved'
+      inflated = Zlib::GzipReader.new(StringIO.new(body.b)).read
+      assert_equal ProxyTestServer::GZIP_PLAINTEXT.b, inflated.b,
+        'body must still be compressed and round-trip to the original payload'
+      if (content_length = last_response['content-length'])
+        assert_equal body.bytesize, content_length.to_i,
+          'Content-Length must match the (compressed) bytes actually forwarded'
+      end
+    end
+  end
+
+  # A raw TCP backend that emits a 103 Early Hints interim response followed by a
+  # final 200. WEBrick can't send 1xx interim responses, so we speak HTTP by hand.
+  def with_early_hints_backend
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    thread = Thread.new do
+      client = server.accept
+      client.gets("\r\n\r\n") # consume request headers
+      client.write("HTTP/1.1 103 Early Hints\r\nLink: </s.css>; rel=preload\r\n\r\n")
+      client.write("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 11\r\nConnection: close\r\n\r\nhello world")
+      client.close
+    rescue IOError, Errno::EPIPE, Errno::ECONNRESET
+      # client went away; nothing to do
+    ensure
+      server.close
+    end
+    yield port
+  ensure
+    thread&.join(2)
+  end
 
   def assert_no_array_header_values(streaming:)
     with_webrick_proxy(streaming: streaming) do |port, proxy|

--- a/test/support/proxy_test_server.rb
+++ b/test/support/proxy_test_server.rb
@@ -3,6 +3,8 @@
 require "webrick"
 require "webrick/https"
 require "socket"
+require "stringio"
+require "zlib"
 
 # A tiny local WEBrick server with a fixed set of routes, used across the whole
 # test suite so tests never touch the public internet. This is the ONLY approved
@@ -75,6 +77,26 @@ module ProxyTestServer
       res.content_type = "text/plain"
       res.body = "chunk-one chunk-two"
     end
+
+    # Always returns a gzip-encoded body with Content-Encoding: gzip, to prove
+    # the proxy forwards it verbatim instead of transparently decoding it (which
+    # would desync Content-Length). GZIP_PLAINTEXT is the decoded payload.
+    server.mount_proc("/gzip") do |_req, res|
+      res.content_type = "text/plain"
+      res["content-encoding"] = "gzip"
+      res.body = ProxyTestServer.gzip(GZIP_PLAINTEXT)
+    end
+  end
+
+  GZIP_PLAINTEXT = ("the quick brown fox " * 32).freeze
+
+  def gzip(string)
+    io = StringIO.new
+    io.set_encoding(Encoding::BINARY)
+    writer = Zlib::GzipWriter.new(io)
+    writer.write(string)
+    writer.close
+    io.string
   end
 
   # A self-signed certificate for 127.0.0.1, generated once per run. It is


### PR DESCRIPTION
**Stacked PR 2/7** — base: `modernization/batch-1-green-loop`. Merge the stack in order (1 → 7).

P0 security hardening of the proxy data path, each fix with regression tests on the new hermetic harness:

- `HttpStreamingResponse#close` — backend connection released on early termination; no more socket/FD leak on HEAD/304/client abort (P0-1)
- Hop-by-hop headers stripped on the *forwarded request* — closes the CL/TE request-smuggling desync; `Connection`-named headers dropped; Rack 2 `HeaderHash` stale-index fix (P0-2)
- Broadened + relocated error handling — backend failures map to 502 (400 malformed URI / 501 unknown method), never raw 500s; defensive close (P0-3)
- `backend_allowed?` hook — groundwork for the SSRF fix; default flip lands in PR 7 (P0-4)
- Streaming `103 Early Hints` no longer returned as the final response (P0-5)
- Non-streaming gunzip / stale Content-Length desync fixed — verbatim pass-through (P0-6)
- Net::HTTP config deduplicated into one source of truth, with VERIFY_PEER asserted on both paths (P1-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
