### PR TITLE
Batch 3: TLS trust anchors, timeouts, response cap, dependency pin

### DIFF
--- a/MODERNIZATION_PLAN.md
+++ b/MODERNIZATION_PLAN.md
@@ -1,9 +1,16 @@
 # rack-proxy — 2026 Modernization + Hardening Roadmap
 
-> **Progress:** Batch 1 (green loop) — DONE on branch `modernization/batch-1-green-loop`.
-> Batch 2 (all six P0 security fixes + P1-4 config dedup) — DONE on branch
-> `modernization/batch-2-security`, each with a regression test on the offline harness.
-> Remaining: Batch 3 (modernization & hardening) and Batch 4 (docs, supply-chain, polish).
+> **Progress:**
+> - Batch 1 (green loop) — DONE, branch `modernization/batch-1-green-loop`.
+> - Batch 2 (six P0 security fixes + P1-4 config dedup) — DONE, branch `modernization/batch-2-security`.
+> - Batch 3 additive hardening — DONE, branch `modernization/batch-3-tls-timeouts`:
+>   `:ca_file`/`:cert_store` (P1-6, incl. hermetic VERIFY_PEER-success test),
+>   `:open_timeout`/`:write_timeout` (P2-2), `:min_version`/`:max_version` (P2-8),
+>   rack pin + `require "rack"` (P1-7), `:max_response_length` (P2-3), example load
+>   safety (P2-5 partial — physical move + README deferred to Batch 4), and a
+>   load-time guard on the monkey-patch (P1-5 interim).
+> - **Still open:** P1-5 the Fiber-based rewrite that retires `net_http_hacked.rb`
+>   (high-risk, deserves a dedicated pass); Batch 4 (docs, supply-chain, README, polish).
 
 Baseline already in place (do **not** redo): VERIFY_PEER default (proxy.rb:149/158), 502-on-connect-error mapping (proxy.rb:172), Rack 3 `Headers`/Rack 2 `HeaderHash` branch (proxy.rb:44-50), non-rewindable body guard (proxy.rb:131), `:logger` option. Everything below builds on that.
 

--- a/MODERNIZATION_PLAN.md
+++ b/MODERNIZATION_PLAN.md
@@ -1,5 +1,10 @@
 # rack-proxy — 2026 Modernization + Hardening Roadmap
 
+> **Progress:** Batch 1 (green loop) — DONE on branch `modernization/batch-1-green-loop`.
+> Batch 2 (all six P0 security fixes + P1-4 config dedup) — DONE on branch
+> `modernization/batch-2-security`, each with a regression test on the offline harness.
+> Remaining: Batch 3 (modernization & hardening) and Batch 4 (docs, supply-chain, polish).
+
 Baseline already in place (do **not** redo): VERIFY_PEER default (proxy.rb:149/158), 502-on-connect-error mapping (proxy.rb:172), Rack 3 `Headers`/Rack 2 `HeaderHash` branch (proxy.rb:44-50), non-rewindable body guard (proxy.rb:131), `:logger` option. Everything below builds on that.
 
 Effort key: **S** ≤ ½ day · **M** ~1-2 days · **L** ~several days. `[agent-DX]` = directly serves the goal of a repo that is easy + safe for AI agents to work in.

--- a/lib/net_http_hacked.rb
+++ b/lib/net_http_hacked.rb
@@ -49,9 +49,12 @@ class Net::HTTP
   def begin_request_hacked(req)
     begin_transport req
     req.exec @socket, @curr_http_version, edit_path(req.path)
+    # Skip ALL 1xx interim responses (100 Continue, 103 Early Hints, etc.), not
+    # just 100 Continue, to reach the final response — matching modern net/http.
+    # Otherwise a backend's 103 Early Hints is mistaken for the final response.
     begin
       res = Net::HTTPResponse.read_new(@socket)
-    end while res.kind_of?(Net::HTTPContinue)
+    end while res.kind_of?(Net::HTTPInformation)
     res.begin_reading_body_hacked(@socket, req.response_body_permitted?)
     @req_hacked, @res_hacked = req, res
     @res_hacked

--- a/lib/net_http_hacked.rb
+++ b/lib/net_http_hacked.rb
@@ -91,3 +91,16 @@ class Net::HTTPResponse
     @socket = nil
   end
 end
+
+# Fail loudly (a warning, so non-streaming users are unaffected) if a future
+# net/http drops the private internals this patch reaches into, instead of
+# breaking mysteriously at request time. The planned Fiber-based rewrite (see
+# MODERNIZATION_PLAN.md P1-5) removes this dependency entirely.
+_rack_proxy_missing_net_http = %i[begin_transport end_transport edit_path].reject do |m|
+  Net::HTTP.private_method_defined?(m) || Net::HTTP.method_defined?(m)
+end
+_rack_proxy_missing_net_http << :read_new unless Net::HTTPResponse.respond_to?(:read_new, true)
+unless _rack_proxy_missing_net_http.empty?
+  warn "net_http_hacked: Net::HTTP internals #{_rack_proxy_missing_net_http.join(', ')} are " \
+       "missing on Ruby #{RUBY_VERSION}; Rack::Proxy streaming may be broken. Use streaming: false."
+end

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -12,8 +12,13 @@ module Rack
 
     attr_accessor :use_ssl, :verify_mode, :read_timeout, :ssl_version, :cert, :key, :logger
 
-    def initialize(request, host, port = nil)
-      @request, @host, @port = request, host, port
+    # An optional block receives the Net::HTTP instance for configuration before
+    # it connects — this is the single source of truth used by Rack::Proxy (see
+    # Rack::Proxy#configure_backend_connection). When no block is given, the
+    # public accessors above are applied instead (backward-compatible path for
+    # direct users of this class).
+    def initialize(request, host, port = nil, &configure)
+      @request, @host, @port, @configure = request, host, port, configure
     end
 
     def body
@@ -68,13 +73,17 @@ module Rack
     # Net::HTTP
     def session
       @session ||= Net::HTTP.new(host, port).tap do |http|
-        http.use_ssl = use_ssl
-        http.verify_mode = verify_mode
-        http.read_timeout = read_timeout
-        http.ssl_version = ssl_version if ssl_version
-        http.cert = cert if cert
-        http.key = key if key
-        http.set_debug_output(logger) if logger
+        if @configure
+          @configure.call(http)
+        else
+          http.use_ssl = use_ssl
+          http.verify_mode = verify_mode
+          http.read_timeout = read_timeout
+          http.ssl_version = ssl_version if ssl_version
+          http.cert = cert if cert
+          http.key = key if key
+          http.set_debug_output(logger) if logger
+        end
         http.start
       end
     end

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -37,12 +37,25 @@ module Rack
       return if connection_closed
 
       response.read_body(&block)
+    rescue StandardError => e
+      # The status/headers are already on the wire, so we can't turn a mid-stream
+      # backend failure into a 502. Log it and re-raise so the server aborts the
+      # transfer (the client sees a truncated response, not a false "complete").
+      logger << "rack-proxy: streaming backend read failed: #{e.class}: #{e.message}\n" if logger.respond_to?(:<<)
+      raise
     ensure
       close_connection
     end
 
     def to_s
       @to_s ||= StringIO.new.tap { |io| each { |line| io << line } }.string
+    end
+
+    # Rack calls #close on the response body when it is done with it, including
+    # when it bails out early (HEAD, 304, a client disconnect). Without this, a
+    # body that is never iterated leaks the backend TCP/TLS connection until GC.
+    def close
+      close_connection
     end
 
     protected
@@ -72,12 +85,22 @@ module Rack
 
     attr_accessor :connection_closed
 
+    # Idempotent, best-effort teardown. Uses @session directly (never the lazy
+    # #session accessor) so closing a response whose body was never read does not
+    # open a connection just to tear it down. Swallows teardown errors: a
+    # half-read or already-reset backend must not crash the app or mask the
+    # original error.
     def close_connection
-      return if connection_closed
+      return if connection_closed || @session.nil?
 
-      session.end_request_hacked
-      session.finish
       self.connection_closed = true
+      begin
+        @session.end_request_hacked
+      ensure
+        @session.finish if @session.started?
+      end
+    rescue StandardError
+      # best-effort: the connection may already be gone
     end
   end
 end

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -4,6 +4,10 @@ require "stringio"
 module Rack
   # Wraps the hacked net/http in a Rack way.
   class HttpStreamingResponse
+    # Raised while streaming when the backend body exceeds max_response_length.
+    # The status/headers are already sent, so the transfer is aborted mid-stream.
+    class ResponseTooLarge < StandardError; end
+
     STATUSES_WITH_NO_ENTITY_BODY = {
       204 => true,
       205 => true,
@@ -11,6 +15,7 @@ module Rack
     }.freeze
 
     attr_accessor :use_ssl, :verify_mode, :read_timeout, :ssl_version, :cert, :key, :logger
+    attr_accessor :max_response_length
 
     # An optional block receives the Net::HTTP instance for configuration before
     # it connects — this is the single source of truth used by Rack::Proxy (see
@@ -41,7 +46,16 @@ module Rack
     def each(&block)
       return if connection_closed
 
-      response.read_body(&block)
+      bytes = 0
+      response.read_body do |chunk|
+        if max_response_length
+          bytes += chunk.bytesize
+          if bytes > max_response_length
+            raise ResponseTooLarge, "backend response exceeded max_response_length=#{max_response_length}"
+          end
+        end
+        block.call(chunk)
+      end
     rescue StandardError => e
       # The status/headers are already on the wire, so we can't turn a mid-stream
       # backend failure into a 502. Log it and re-raise so the server aborts the

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -1,3 +1,4 @@
+require "rack"
 require "net_http_hacked"
 require "rack/http_streaming_response"
 require "rack/proxy/version"
@@ -97,9 +98,22 @@ module Rack
       @streaming = opts.fetch(:streaming, true)
       @backend = opts[:backend] ? URI(opts[:backend]) : nil
       @read_timeout = opts.fetch(:read_timeout, 60)
+      # Connect and per-write deadlines. Without these a slow/hostile backend can
+      # stall a thread for Net::HTTP's 60s defaults even with a small read_timeout.
+      @open_timeout = opts[:open_timeout]
+      @write_timeout = opts[:write_timeout]
+      # :ssl_version pins an exact protocol and is deprecated (it forbids TLS 1.3);
+      # prefer :min_version / :max_version, which map to Net::HTTP#min_version=/#max_version=.
       @ssl_version = opts[:ssl_version]
+      @min_version = opts[:min_version]
+      @max_version = opts[:max_version]
       @cert = opts[:cert]
       @key = opts[:key]
+      # Trust anchors for VERIFY_PEER: :ca_file is a PEM bundle path, :cert_store
+      # an OpenSSL::X509::Store. Use these for private-CA backends instead of
+      # disabling verification with ssl_verify_none.
+      @ca_file = opts[:ca_file]
+      @cert_store = opts[:cert_store]
       # SSL verification: defaults to VERIFY_PEER (Ruby's Net::HTTP default).
       # Pass ssl_verify_none: true to explicitly disable cert verification, or
       # pass verify_mode: <OpenSSL::SSL::VERIFY_*> for full control.
@@ -190,13 +204,13 @@ module Rack
 
         if @streaming
           # streaming response (the actual network communication is deferred, a.k.a. streamed)
-          target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port)
-          configure_backend_connection(target_response, use_ssl: use_ssl, read_timeout: read_timeout)
+          target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port) do |http|
+            configure_backend_connection(http, use_ssl: use_ssl, read_timeout: read_timeout)
+          end
           target_response.logger = @logger if @logger
         else
           http = Net::HTTP.new(backend.host, backend.port)
           configure_backend_connection(http, use_ssl: use_ssl, read_timeout: read_timeout)
-          http.set_debug_output(@logger) if @logger
 
           target_response = http.start do
             http.request(target_request)
@@ -235,16 +249,27 @@ module Rack
       nil
     end
 
-    # Single source of truth for TLS/timeout setup, applied identically to both
-    # the streaming response and the non-streaming Net::HTTP connection so a TLS
-    # option (notably the VERIFY_PEER default) can never land on only one path.
+    # Single source of truth for TLS/timeout setup, applied to the (real
+    # Net::HTTP) connection on both the streaming and non-streaming paths so a
+    # TLS option — notably the VERIFY_PEER default — can never land on only one.
     def configure_backend_connection(conn, use_ssl:, read_timeout:)
       conn.use_ssl = use_ssl
       conn.read_timeout = read_timeout
-      conn.ssl_version = @ssl_version if @ssl_version
-      conn.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_PEER) if use_ssl
-      conn.cert = @cert if @cert
-      conn.key = @key if @key
+      conn.open_timeout = @open_timeout if @open_timeout
+      conn.write_timeout = @write_timeout if @write_timeout
+
+      if use_ssl
+        conn.verify_mode = @verify_mode || OpenSSL::SSL::VERIFY_PEER
+        conn.ca_file = @ca_file if @ca_file
+        conn.cert_store = @cert_store if @cert_store
+        conn.min_version = @min_version if @min_version
+        conn.max_version = @max_version if @max_version
+        conn.ssl_version = @ssl_version if @ssl_version # deprecated; prefer min/max_version
+        conn.cert = @cert if @cert
+        conn.key = @key if @key
+      end
+
+      conn.set_debug_output(@logger) if @logger
       conn
     end
   end

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -102,6 +102,10 @@ module Rack
       # stall a thread for Net::HTTP's 60s defaults even with a small read_timeout.
       @open_timeout = opts[:open_timeout]
       @write_timeout = opts[:write_timeout]
+      # Optional cap (in bytes) on the backend response size, to bound memory
+      # against a hostile/huge backend. Enforced incrementally while streaming and
+      # via the declared Content-Length / buffered size otherwise. Default: no cap.
+      @max_response_length = opts[:max_response_length]
       # :ssl_version pins an exact protocol and is deprecated (it forbids TLS 1.3);
       # prefer :min_version / :max_version, which map to Net::HTTP#min_version=/#max_version=.
       @ssl_version = opts[:ssl_version]
@@ -236,10 +240,37 @@ module Rack
       # consistent on Rack 2 for any downstream middleware.
       headers.keys.each { |k| headers.delete(k) if HOP_BY_HOP_HEADERS[k.downcase] }
 
+      return [502, {}, []] if response_too_large?(target_response, headers, body)
+
       [code, headers, body]
     end
 
     private
+
+    # Enforce :max_response_length. Returns true (→ 502) when the response is
+    # already known to be too large. For streaming, a declared oversize is
+    # rejected up-front (the connection is closed) and the incremental limit is
+    # armed on the body for chunked/unknown-length responses; for non-streaming,
+    # the body is already buffered so we check its actual size. Returns false
+    # (allow) when no cap is set.
+    def response_too_large?(target_response, headers, body)
+      return false unless @max_response_length
+
+      declared = headers['Content-Length']
+      declared_oversize = declared && declared.to_i > @max_response_length
+
+      if target_response.respond_to?(:max_response_length=)
+        if declared_oversize
+          target_response.close
+          return true
+        end
+        target_response.max_response_length = @max_response_length
+        false
+      else
+        buffered = body.sum { |part| part.to_s.bytesize }
+        declared_oversize || buffered > @max_response_length
+      end
+    end
 
     # Resolve the Net::HTTP request class for an HTTP method, or nil if there is
     # no matching Net::HTTP::<Verb> (unknown/unsupported method -> 501).

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -17,6 +17,20 @@ module Rack
       'upgrade' => true
     }.freeze
 
+    # Backend/network failures that must surface as 502 Bad Gateway rather than
+    # crashing the proxy with a raw 500. Construction- and policy-time failures
+    # are mapped separately (400/501/502) in #perform_request.
+    BACKEND_ERRORS = [
+      Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ECONNABORTED,
+      Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ETIMEDOUT, Errno::EPIPE,
+      SocketError,
+      Timeout::Error,               # includes Net::OpenTimeout
+      Net::ReadTimeout, Net::WriteTimeout,
+      IOError,                      # includes EOFError
+      OpenSSL::SSL::SSLError,
+      Net::ProtocolError            # includes Net::HTTPBadResponse
+    ].freeze
+
     class << self
       def extract_http_request_headers(env)
         headers = env.reject do |k, v|
@@ -24,6 +38,17 @@ module Rack
         end.map do |k, v|
           [reconstruct_header_name(k), v]
         end.then { |pairs| build_header_hash(pairs) }
+
+        # Strip hop-by-hop headers before forwarding. Relaying the client's
+        # Connection / TE / Transfer-Encoding (etc.) enables request smuggling
+        # and confuses the backend — these are connection-scoped, not end-to-end.
+        # Per RFC 7230 §6.1 any field named in the inbound Connection header is
+        # itself hop-by-hop for this hop. Use #delete (not #reject!) so the
+        # returned HeaderHash's case-insensitive index stays consistent on Rack 2.
+        connection_named = headers['Connection'].to_s.downcase.split(/,\s*/).map(&:strip)
+        headers.keys.each do |key|
+          headers.delete(key) if HOP_BY_HOP_HEADERS[key.downcase] || connection_named.include?(key.downcase)
+        end
 
         x_forwarded_for = (headers['X-Forwarded-For'].to_s.split(/, +/) << env['REMOTE_ADDR']).join(', ')
 
@@ -105,58 +130,72 @@ module Rack
       triplet
     end
 
+    # SSRF guardrail. Override to restrict which backends this proxy may connect
+    # to; `backend` responds to #host, #port and #scheme. Return false to refuse,
+    # which makes the proxy respond 502. The default allows any backend for
+    # backward compatibility — but when no :backend is configured the destination
+    # is derived from the client-controlled Host header, so a subclass in that
+    # setup SHOULD override this to allowlist expected hosts (or set a fixed
+    # :backend). See the README "Security considerations".
+    def backend_allowed?(backend)
+      true
+    end
+
     protected
 
     def perform_request(env)
       source_request = Rack::Request.new(env)
 
-      # Initialize request
-      if source_request.fullpath == ""
-        full_path = URI.parse(env['REQUEST_URI']).request_uri
-      else
-        full_path = source_request.fullpath
-      end
-
-      target_request = Net::HTTP.const_get(source_request.request_method.capitalize, false).new(full_path)
-
-      # Setup headers
-      target_request.initialize_http_header(self.class.extract_http_request_headers(source_request.env))
-
-      # Setup body
-      if target_request.request_body_permitted? && source_request.body
-        target_request.body_stream    = source_request.body
-        target_request.content_length = source_request.content_length.to_i
-        target_request.content_type   = source_request.content_type if source_request.content_type
-        target_request.body_stream.rewind if target_request.body_stream.respond_to?(:rewind)
-      end
-
-      # Use basic auth if we have to
-      target_request.basic_auth(@username, @password) if @username && @password
-
-      backend = env.delete('rack.backend') || @backend || source_request
-      use_ssl = backend.scheme == "https" || @cert
-      read_timeout = env.delete('http.read_timeout') || @read_timeout
-
-      # Create the response
+      # Everything that can fail on a hostile/unreachable request or backend is
+      # mapped to a status code here so the proxy never surfaces a raw 500:
+      #   400 malformed request URI, 501 unknown method, 502 backend failure.
       begin
+        # Initialize request
+        if source_request.fullpath == ""
+          full_path = URI.parse(env['REQUEST_URI']).request_uri
+        else
+          full_path = source_request.fullpath
+        end
+
+        request_class = net_http_request_class(source_request.request_method)
+        return [501, {}, []] if request_class.nil?
+
+        target_request = request_class.new(full_path)
+
+        # Setup headers
+        target_request.initialize_http_header(self.class.extract_http_request_headers(source_request.env))
+
+        # Forward the backend response verbatim: don't let Net::HTTP transparently
+        # gzip-decode it, which would leave the forwarded Content-Length describing
+        # the compressed size (a body/Content-Length desync). The client decodes
+        # its own content-encoding.
+        target_request.instance_variable_set(:@decode_content, false) if target_request.instance_variable_defined?(:@decode_content)
+
+        # Setup body
+        if target_request.request_body_permitted? && source_request.body
+          target_request.body_stream    = source_request.body
+          target_request.content_length = source_request.content_length.to_i
+          target_request.content_type   = source_request.content_type if source_request.content_type
+          target_request.body_stream.rewind if target_request.body_stream.respond_to?(:rewind)
+        end
+
+        # Use basic auth if we have to
+        target_request.basic_auth(@username, @password) if @username && @password
+
+        backend = env.delete('rack.backend') || @backend || source_request
+        return [502, {}, []] unless backend_allowed?(backend)
+
+        use_ssl = backend.scheme == "https" || @cert
+        read_timeout = env.delete('http.read_timeout') || @read_timeout
+
         if @streaming
           # streaming response (the actual network communication is deferred, a.k.a. streamed)
           target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port)
-          target_response.use_ssl = use_ssl
-          target_response.read_timeout = read_timeout
-          target_response.ssl_version = @ssl_version if @ssl_version
-          target_response.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_PEER) if use_ssl
-          target_response.cert = @cert if @cert
-          target_response.key = @key if @key
+          configure_backend_connection(target_response, use_ssl: use_ssl, read_timeout: read_timeout)
           target_response.logger = @logger if @logger
         else
           http = Net::HTTP.new(backend.host, backend.port)
-          http.use_ssl = use_ssl if use_ssl
-          http.read_timeout = read_timeout
-          http.ssl_version = @ssl_version if @ssl_version
-          http.verify_mode = @verify_mode || OpenSSL::SSL::VERIFY_PEER if use_ssl
-          http.cert = @cert if @cert
-          http.key = @key if @key
+          configure_backend_connection(http, use_ssl: use_ssl, read_timeout: read_timeout)
           http.set_debug_output(@logger) if @logger
 
           target_response = http.start do
@@ -168,18 +207,45 @@ module Rack
         headers = self.class.normalize_headers(target_response.respond_to?(:headers) ? target_response.headers : target_response.to_hash)
         body    = target_response.body || []
         body    = [body] unless body.respond_to?(:each)
-      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ETIMEDOUT, Net::OpenTimeout, SocketError
+      rescue URI::InvalidURIError
+        return [400, {}, []]
+      rescue *BACKEND_ERRORS => e
+        @logger << "rack-proxy: backend request failed: #{e.class}: #{e.message}\n" if @logger.respond_to?(:<<)
         return [502, {}, []]
       end
 
       # No entity body for status codes that don't allow one (1xx, 204, 304)
       body = [] if Rack::Utils::STATUS_WITH_NO_ENTITY_BODY[code.to_i]
 
-      # According to https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3.1Acc
-      # should remove hop-by-hop header fields
-      headers.reject! { |k| HOP_BY_HOP_HEADERS[k.downcase] }
+      # Remove hop-by-hop header fields from the response. Use #delete (not
+      # #reject!) so the returned HeaderHash's case-insensitive index stays
+      # consistent on Rack 2 for any downstream middleware.
+      headers.keys.each { |k| headers.delete(k) if HOP_BY_HOP_HEADERS[k.downcase] }
 
       [code, headers, body]
+    end
+
+    private
+
+    # Resolve the Net::HTTP request class for an HTTP method, or nil if there is
+    # no matching Net::HTTP::<Verb> (unknown/unsupported method -> 501).
+    def net_http_request_class(method)
+      Net::HTTP.const_get(method.capitalize, false)
+    rescue NameError
+      nil
+    end
+
+    # Single source of truth for TLS/timeout setup, applied identically to both
+    # the streaming response and the non-streaming Net::HTTP connection so a TLS
+    # option (notably the VERIFY_PEER default) can never land on only one path.
+    def configure_backend_connection(conn, use_ssl:, read_timeout:)
+      conn.use_ssl = use_ssl
+      conn.read_timeout = read_timeout
+      conn.ssl_version = @ssl_version if @ssl_version
+      conn.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_PEER) if use_ssl
+      conn.cert = @cert if @cert
+      conn.key = @key if @key
+      conn
     end
   end
 end

--- a/lib/rack_proxy_examples/example_service_proxy.rb
+++ b/lib/rack_proxy_examples/example_service_proxy.rb
@@ -37,4 +37,9 @@ class ExampleServiceProxy < Rack::Proxy
   end
 end
 
-Rails.application.config.middleware.use ExampleServiceProxy, backend: ENV['SERVICE_URL'], streaming: false
+# Only wire into the middleware stack when running inside a booted Rails app, so
+# this file is safe to require anywhere (doc/RBI tooling, a stray require) without
+# crashing or silently installing a proxy.
+if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+  Rails.application.config.middleware.use ExampleServiceProxy, backend: ENV['SERVICE_URL'], streaming: false
+end

--- a/lib/rack_proxy_examples/forward_host.rb
+++ b/lib/rack_proxy_examples/forward_host.rb
@@ -21,4 +21,7 @@ class ForwardHost < Rack::Proxy
 
 end
 
-Rails.application.config.middleware.use ForwardHost, backend: 'http://example.com', streaming: false
+# Only wire into the middleware stack when running inside a booted Rails app.
+if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+  Rails.application.config.middleware.use ForwardHost, backend: 'http://example.com', streaming: false
+end

--- a/lib/rack_proxy_examples/rack_php_proxy.rb
+++ b/lib/rack_proxy_examples/rack_php_proxy.rb
@@ -34,4 +34,7 @@ class RackPhpProxy < Rack::Proxy
   end
 end
 
-Rails.application.config.middleware.use RackPhpProxy, backend: ENV["HTTP_HOST"]='http://php.net', streaming: false
+# Only wire into the middleware stack when running inside a booted Rails app.
+if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+  Rails.application.config.middleware.use RackPhpProxy, backend: 'http://php.net', streaming: false
+end

--- a/lib/rack_proxy_examples/trusting_proxy.rb
+++ b/lib/rack_proxy_examples/trusting_proxy.rb
@@ -19,7 +19,10 @@ class TrustingProxy < Rack::Proxy
 end
 
 # Pass ssl_verify_none: true to skip TLS certificate verification.
-Rails.application.config.middleware.use TrustingProxy,
-  backend: 'https://self-signed.badssl.com',
-  streaming: false,
-  ssl_verify_none: true
+# Only wire into the middleware stack when running inside a booted Rails app.
+if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+  Rails.application.config.middleware.use TrustingProxy,
+    backend: 'https://self-signed.badssl.com',
+    streaming: false,
+    ssl_verify_none: true
+end

--- a/rack-proxy.gemspec
+++ b/rack-proxy.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + %w[README.md LICENSE rack-proxy.gemspec]
   s.require_paths = ["lib"]
 
-  s.add_dependency("rack")
+  s.add_dependency("rack", ">= 2.0", "< 4")
   s.add_development_dependency("rack-test")
   s.add_development_dependency("test-unit")
   s.add_development_dependency("webrick")

--- a/test/examples_test.rb
+++ b/test/examples_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+require "rack/proxy"
+
+# The bundled examples ship on the gem load path, so they must be safe to
+# require outside a Rails app: no crash and no side effect (they only wire
+# themselves into the middleware stack when Rails is booted). This guards
+# doc/RBI tooling and stray requires.
+class ExamplesTest < Test::Unit::TestCase
+  EXAMPLES = {
+    "rack_proxy_examples/forward_host"          => "ForwardHost",
+    "rack_proxy_examples/rack_php_proxy"        => "RackPhpProxy",
+    "rack_proxy_examples/trusting_proxy"        => "TrustingProxy",
+    "rack_proxy_examples/example_service_proxy" => "ExampleServiceProxy"
+  }.freeze
+
+  def test_examples_are_safe_to_require_without_rails
+    assert !defined?(Rails), "this test assumes Rails is not loaded"
+
+    EXAMPLES.each do |path, class_name|
+      assert_nothing_raised("requiring #{path} outside Rails must not raise") do
+        require path
+      end
+      assert Object.const_defined?(class_name), "#{class_name} should be defined after requiring #{path}"
+      assert Object.const_get(class_name).ancestors.include?(Rack::Proxy),
+        "#{class_name} should subclass Rack::Proxy"
+    end
+  end
+end

--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -52,4 +52,29 @@ class HttpStreamingResponseTest < Test::Unit::TestCase
     assert_equal body.to_s, body.to_s
   end
 
+  # P0-1: Rack servers call body.close; it must be public.
+  def test_body_responds_to_close
+    assert @response.body.respond_to?(:close)
+  end
+
+  # P0-1: closing a response whose body was never read must NOT dial the backend
+  # just to tear it down (i.e. it must not trigger the lazy session).
+  def test_close_without_reading_opens_no_connection
+    req = Net::HTTP::Get.new("/")
+    response = Rack::HttpStreamingResponse.new(req, "127.0.0.1", @server.config[:Port])
+    response.use_ssl = false
+    assert_nothing_raised { response.close }
+    assert_nil response.instance_variable_get(:@session), "close must not open a session"
+  end
+
+  # P0-1: after streaming, the backend connection must be finished, and close
+  # must be idempotent.
+  def test_close_releases_connection_after_reading
+    @response.body.each { |_chunk| }
+    session = @response.instance_variable_get(:@session)
+    assert_not_nil session
+    assert !session.started?, "backend connection must be finished after streaming"
+    assert_nothing_raised { @response.close }
+  end
+
 end

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -55,8 +55,10 @@ class RackProxyTest < Test::Unit::TestCase
     end
   end
 
+  # Uses the modern :min_version option (:ssl_version is deprecated). The other
+  # _tls test below still exercises :ssl_version for backward compatibility.
   def test_https_streaming_tls
-    with_webrick_proxy(ssl: true, ssl_verify_none: true, ssl_version: :TLSv1_2) do |port, proxy|
+    with_webrick_proxy(ssl: true, ssl_verify_none: true, min_version: :TLS1_2) do |port, proxy|
       proxy.host = "127.0.0.1:#{port}"
       get 'https://example.com'
       assert last_response.ok?
@@ -320,6 +322,58 @@ class RackProxyTest < Test::Unit::TestCase
     end
   end
 
+  # P1-6: with a :ca_file that trusts the backend's CA, the default VERIFY_PEER
+  # must *accept* the (otherwise-untrusted) cert. This is the keystone hermetic
+  # VERIFY_PEER-success test that previously required a live host.
+  def test_https_ca_file_accepts_trusted_cert_non_streaming
+    with_webrick_proxy(ssl: true, ca_signed: true, streaming: false, ca_file: ProxyTestServer.ca_file) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get 'https://example.com/'
+      assert last_response.ok?, 'VERIFY_PEER must accept a cert signed by the configured ca_file'
+      assert_match(/Example Domain/, last_response.body)
+    end
+  end
+
+  def test_https_ca_file_accepts_trusted_cert_streaming
+    with_webrick_proxy(ssl: true, ca_signed: true, streaming: true, ca_file: ProxyTestServer.ca_file) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get 'https://example.com/'
+      assert last_response.ok?
+      assert_match(/Example Domain/, last_response.body)
+    end
+  end
+
+  # Without the ca_file, the same CA-signed cert is untrusted and must be rejected
+  # (-> 502), proving the ca_file is what establishes trust.
+  def test_https_ca_signed_cert_rejected_without_ca_file
+    with_webrick_proxy(ssl: true, ca_signed: true, streaming: false) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get 'https://example.com/'
+      assert_equal 502, last_response.status
+    end
+  end
+
+  # P2-2: :open_timeout / :write_timeout must be wired onto the connection
+  # (Net::HTTP defaults them to 60s, unreachable via :read_timeout alone).
+  def test_connect_and_write_timeouts_are_applied
+    proxy = Rack::Proxy.new(read_timeout: 5, open_timeout: 3, write_timeout: 7)
+    http = Net::HTTP.new("127.0.0.1", 80)
+    proxy.send(:configure_backend_connection, http, use_ssl: false, read_timeout: 5)
+    assert_equal 5, http.read_timeout
+    assert_equal 3, http.open_timeout
+    assert_equal 7, http.write_timeout
+  end
+
+  # P1-6: :ca_file / :cert_store must be wired onto the TLS connection.
+  def test_ca_file_and_cert_store_are_applied
+    store = OpenSSL::X509::Store.new
+    proxy = Rack::Proxy.new(ca_file: "/tmp/some-ca.pem", cert_store: store)
+    http = Net::HTTP.new("127.0.0.1", 443)
+    proxy.send(:configure_backend_connection, http, use_ssl: true, read_timeout: 5)
+    assert_equal "/tmp/some-ca.pem", http.ca_file
+    assert_same store, http.cert_store
+  end
+
   # Issue #80: a :logger option should pipe Net::HTTP debug output to the
   # given sink (anything responding to #<<). We use a StringIO to capture it.
   def test_logger_captures_request_in_non_streaming
@@ -508,8 +562,8 @@ class RackProxyTest < Test::Unit::TestCase
   # the network. Pass ssl: true for an HTTPS backend with a self-signed cert; all
   # other keyword options are forwarded to the proxy (e.g. streaming:,
   # ssl_verify_none:, ssl_version:, logger:).
-  def with_webrick_proxy(ssl: false, **proxy_opts)
-    server, port = ProxyTestServer.start_server(ssl: ssl)
+  def with_webrick_proxy(ssl: false, ca_signed: false, **proxy_opts)
+    server, port = ProxyTestServer.start_server(ssl: ssl, ca_signed: ca_signed)
 
     proxy = HostProxy.new(**proxy_opts)
     @app = proxy

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -285,12 +285,30 @@ class RackProxyTest < Test::Unit::TestCase
 
   # The local HTTPS server uses a self-signed cert, so the default VERIFY_PEER
   # must reject it. This is the hermetic replacement for the old badssl.com test
-  # and is now the primary regression guard for the VERIFY_PEER default.
+  # and is now the primary regression guard for the VERIFY_PEER default. Since
+  # Batch 2 maps backend failures to 502 (rather than raising), we assert 502 and
+  # use the logger to confirm the cause is specifically a TLS verification error.
   def test_https_default_rejects_invalid_certificate
-    with_webrick_proxy(ssl: true, streaming: false) do |port, proxy|
+    sink = StringIO.new
+    with_webrick_proxy(ssl: true, streaming: false, logger: sink) do |port, proxy|
       proxy.host = "127.0.0.1:#{port}"
-      error = assert_raise(OpenSSL::SSL::SSLError) { get 'https://example.com/' }
-      assert_match(/certificate verify failed/, error.message)
+      get 'https://example.com/'
+      assert_equal 502, last_response.status,
+        'a backend cert failing VERIFY_PEER must become 502, not a raised 500'
+      assert_match(/SSLError|certificate verify failed/, sink.string,
+        "expected the 502 to be caused by a TLS verification failure, got: #{sink.string.inspect}")
+    end
+  end
+
+  # Same guard for the default (streaming) path, which previously had no
+  # VERIFY_PEER coverage at all (P1-4 deduped the TLS config into one place).
+  def test_https_default_rejects_invalid_certificate_streaming
+    sink = StringIO.new
+    with_webrick_proxy(ssl: true, streaming: true, logger: sink) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get 'https://example.com/'
+      assert_equal 502, last_response.status
+      assert_match(/SSLError|certificate verify failed/, sink.string)
     end
   end
 
@@ -353,7 +371,125 @@ class RackProxyTest < Test::Unit::TestCase
     end
   end
 
+  # P0-2: hop-by-hop headers (and any header named by Connection) must be
+  # stripped from the FORWARDED REQUEST, closing the CL/TE smuggling surface.
+  def test_request_hop_by_hop_headers_are_stripped
+    env = {
+      'REMOTE_ADDR'            => '10.0.0.1',
+      'HTTP_ACCEPT'            => 'text/html',
+      'HTTP_CONNECTION'        => 'keep-alive, X-Purge-Me',
+      'HTTP_KEEP_ALIVE'        => 'timeout=5',
+      'HTTP_TE'                => 'trailers',
+      'HTTP_TRANSFER_ENCODING' => 'chunked',
+      'HTTP_PROXY_AUTHORIZATION' => 'Basic zzz',
+      'HTTP_UPGRADE'           => 'websocket',
+      'HTTP_X_PURGE_ME'        => 'please',
+      'HTTP_AUTHORIZATION'     => 'Bearer keep-me'
+    }
+    headers = Rack::Proxy.extract_http_request_headers(env)
+
+    %w[Connection Keep-Alive Te Transfer-Encoding Proxy-Authorization Upgrade].each do |h|
+      assert !headers.key?(h), "#{h} is hop-by-hop and must not be forwarded"
+    end
+    assert !headers.key?('X-Purge-Me'), 'a header named in Connection must be dropped'
+    assert_equal 'text/html', headers['Accept'], 'end-to-end headers must survive'
+    assert_equal 'Bearer keep-me', headers['Authorization'], 'end-to-end Authorization must survive'
+  end
+
+  # P0-6: a gzip-encoded backend body must be forwarded verbatim (still
+  # compressed, Content-Encoding intact, Content-Length matching the bytes sent),
+  # not transparently inflated (which desyncs Content-Length).
+  def test_gzip_body_is_forwarded_verbatim_non_streaming
+    assert_gzip_forwarded_verbatim(streaming: false)
+  end
+
+  def test_gzip_body_is_forwarded_verbatim_streaming
+    assert_gzip_forwarded_verbatim(streaming: true)
+  end
+
+  # P0-3: a method with no Net::HTTP::<Verb> class must be 501, not a raised 500.
+  # (Net::HTTP does define WebDAV verbs like PROPFIND, so use a truly unknown one.)
+  def test_unknown_method_returns_501
+    with_webrick_proxy(streaming: false) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      env = Rack::MockRequest.env_for("/", method: "GET")
+      env["REQUEST_METHOD"] = "BOGUSVERB"
+      status, _headers, _body = proxy.call(env)
+      assert_equal 501, status
+    end
+  end
+
+  # P0-4: a backend refused by backend_allowed? must 502 even when the backend
+  # is reachable and would otherwise succeed.
+  def test_disallowed_backend_returns_502
+    with_webrick_proxy(streaming: false) do |port, proxy|
+      def proxy.backend_allowed?(_backend); false; end
+      proxy.host = "127.0.0.1:#{port}"
+      get "/"
+      assert_equal 502, last_response.status
+    end
+  end
+
+  def test_backend_allowed_by_default
+    proxy = Rack::Proxy.new
+    assert proxy.send(:backend_allowed?, URI("http://198.51.100.7:80")),
+      'default must allow any backend for backward compatibility'
+  end
+
+  # P0-5: an interim 103 Early Hints from the backend must be skipped so the
+  # final 200 (and its body) is returned, on the default streaming path.
+  def test_early_hints_103_is_skipped_streaming
+    with_early_hints_backend do |port|
+      proxy = HostProxy.new(streaming: true)
+      @app = proxy
+      proxy.host = "127.0.0.1:#{port}"
+      get "/"
+      assert_equal 200, last_response.status.to_i, 'must return the final 200, not the interim 103'
+      assert_equal 'hello world', last_response.body
+    end
+  ensure
+    @app = nil
+  end
+
   private
+
+  def assert_gzip_forwarded_verbatim(streaming:)
+    with_webrick_proxy(streaming: streaming) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get "/gzip"
+      assert last_response.ok?
+      body = last_response.body
+      assert_equal 'gzip', last_response['content-encoding'], 'Content-Encoding must be preserved'
+      inflated = Zlib::GzipReader.new(StringIO.new(body.b)).read
+      assert_equal ProxyTestServer::GZIP_PLAINTEXT.b, inflated.b,
+        'body must still be compressed and round-trip to the original payload'
+      if (content_length = last_response['content-length'])
+        assert_equal body.bytesize, content_length.to_i,
+          'Content-Length must match the (compressed) bytes actually forwarded'
+      end
+    end
+  end
+
+  # A raw TCP backend that emits a 103 Early Hints interim response followed by a
+  # final 200. WEBrick can't send 1xx interim responses, so we speak HTTP by hand.
+  def with_early_hints_backend
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    thread = Thread.new do
+      client = server.accept
+      client.gets("\r\n\r\n") # consume request headers
+      client.write("HTTP/1.1 103 Early Hints\r\nLink: </s.css>; rel=preload\r\n\r\n")
+      client.write("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 11\r\nConnection: close\r\n\r\nhello world")
+      client.close
+    rescue IOError, Errno::EPIPE, Errno::ECONNRESET
+      # client went away; nothing to do
+    ensure
+      server.close
+    end
+    yield port
+  ensure
+    thread&.join(2)
+  end
 
   def assert_no_array_header_values(streaming:)
     with_webrick_proxy(streaming: streaming) do |port, proxy|

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -505,6 +505,43 @@ class RackProxyTest < Test::Unit::TestCase
     @app = nil
   end
 
+  # P2-3: :max_response_length caps the backend response size.
+  def test_max_response_length_rejects_declared_oversize_non_streaming
+    with_webrick_proxy(streaming: false, max_response_length: 10) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get "/" # body is well over 10 bytes, with a Content-Length
+      assert_equal 502, last_response.status
+    end
+  end
+
+  def test_max_response_length_rejects_declared_oversize_streaming
+    with_webrick_proxy(streaming: true, max_response_length: 10) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get "/"
+      assert_equal 502, last_response.status
+    end
+  end
+
+  # No Content-Length (chunked): the cap must still fire incrementally while
+  # streaming, aborting the transfer with ResponseTooLarge.
+  def test_max_response_length_enforced_while_streaming_chunked
+    with_webrick_proxy(streaming: true, max_response_length: 5) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      status, _headers, body = proxy.call(Rack::MockRequest.env_for("/chunked"))
+      assert_equal 200, status.to_i, "headers precede the body, so status is still 200"
+      assert_raise(Rack::HttpStreamingResponse::ResponseTooLarge) { body.each { |_chunk| } }
+    end
+  end
+
+  def test_max_response_length_allows_within_limit
+    with_webrick_proxy(streaming: false, max_response_length: 100_000) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get "/"
+      assert last_response.ok?
+      assert_match(/Example Domain/, last_response.body)
+    end
+  end
+
   private
 
   def assert_gzip_forwarded_verbatim(streaming:)

--- a/test/support/proxy_test_server.rb
+++ b/test/support/proxy_test_server.rb
@@ -5,6 +5,7 @@ require "webrick/https"
 require "socket"
 require "stringio"
 require "zlib"
+require "tempfile"
 
 # A tiny local WEBrick server with a fixed set of routes, used across the whole
 # test suite so tests never touch the public internet. This is the ONLY approved
@@ -25,9 +26,12 @@ module ProxyTestServer
   module_function
 
   # Starts a server on an ephemeral port bound to 127.0.0.1 and returns
-  # [server, port]. Pass ssl: true for HTTPS with an auto-generated self-signed
-  # certificate (untrusted on purpose — it exercises the VERIFY_PEER default).
-  def start_server(ssl: false)
+  # [server, port]. Pass ssl: true for HTTPS. By default the cert is self-signed
+  # (untrusted on purpose — exercises the VERIFY_PEER default rejecting it). Pass
+  # ca_signed: true for a cert signed by ProxyTestServer.ca_file's CA, so a proxy
+  # configured with that ca_file verifies successfully (the VERIFY_PEER *success*
+  # path, offline).
+  def start_server(ssl: false, ca_signed: false)
     options = {
       Port: 0,
       BindAddress: "127.0.0.1",
@@ -36,7 +40,7 @@ module ProxyTestServer
     }
 
     if ssl
-      cert, key = self_signed_cert
+      cert, key = ca_signed ? ca_signed_cert : self_signed_cert
       options[:SSLEnable]      = true
       options[:SSLCertificate] = cert
       options[:SSLPrivateKey]  = key
@@ -125,6 +129,71 @@ module ProxyTestServer
       cert.sign(key, OpenSSL::Digest.new("SHA256"))
 
       [cert, key]
+    end
+  end
+
+  # A test certificate authority, generated once per run. Its cert (in PEM form
+  # at #ca_file) can be handed to a proxy as :ca_file so it trusts #ca_signed_cert.
+  def certificate_authority
+    @certificate_authority ||= begin
+      key = OpenSSL::PKey::RSA.new(2048)
+      cert = OpenSSL::X509::Certificate.new
+      name = OpenSSL::X509::Name.parse("/CN=rack-proxy-test-ca")
+      cert.version    = 2
+      cert.serial     = 1
+      cert.subject    = name
+      cert.issuer     = name
+      cert.public_key = key.public_key
+      cert.not_before = Time.now - 3600
+      cert.not_after  = Time.now + (365 * 24 * 3600)
+
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = cert
+      ef.issuer_certificate  = cert
+      cert.add_extension(ef.create_extension("basicConstraints", "CA:TRUE", true))
+      cert.add_extension(ef.create_extension("keyUsage", "keyCertSign, cRLSign", true))
+      cert.sign(key, OpenSSL::Digest.new("SHA256"))
+
+      [cert, key]
+    end
+  end
+
+  # A 127.0.0.1 leaf certificate signed by #certificate_authority (SAN included),
+  # so default VERIFY_PEER accepts it when the proxy is given #ca_file.
+  def ca_signed_cert
+    @ca_signed_cert ||= begin
+      ca_cert, ca_key = certificate_authority
+      key = OpenSSL::PKey::RSA.new(2048)
+      cert = OpenSSL::X509::Certificate.new
+      cert.version    = 2
+      cert.serial     = 2
+      cert.subject    = OpenSSL::X509::Name.parse("/CN=127.0.0.1")
+      cert.issuer     = ca_cert.subject
+      cert.public_key = key.public_key
+      cert.not_before = Time.now - 3600
+      cert.not_after  = Time.now + (365 * 24 * 3600)
+
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = cert
+      ef.issuer_certificate  = ca_cert
+      cert.add_extension(ef.create_extension("basicConstraints", "CA:FALSE", true))
+      cert.add_extension(ef.create_extension("subjectAltName", "IP:127.0.0.1,DNS:localhost", false))
+      cert.sign(ca_key, OpenSSL::Digest.new("SHA256"))
+
+      [cert, key]
+    end
+  end
+
+  # Path to a PEM file containing the test CA cert. The Tempfile is held in a
+  # module ivar so it isn't unlinked by GC for the life of the process.
+  def ca_file
+    @ca_file ||= begin
+      ca_cert, _ = certificate_authority
+      file = Tempfile.new(["rack-proxy-test-ca", ".pem"])
+      file.write(ca_cert.to_pem)
+      file.flush
+      @ca_file_tempfile = file # keep a reference alive
+      file.path
     end
   end
 

--- a/test/support/proxy_test_server.rb
+++ b/test/support/proxy_test_server.rb
@@ -3,6 +3,8 @@
 require "webrick"
 require "webrick/https"
 require "socket"
+require "stringio"
+require "zlib"
 
 # A tiny local WEBrick server with a fixed set of routes, used across the whole
 # test suite so tests never touch the public internet. This is the ONLY approved
@@ -75,6 +77,26 @@ module ProxyTestServer
       res.content_type = "text/plain"
       res.body = "chunk-one chunk-two"
     end
+
+    # Always returns a gzip-encoded body with Content-Encoding: gzip, to prove
+    # the proxy forwards it verbatim instead of transparently decoding it (which
+    # would desync Content-Length). GZIP_PLAINTEXT is the decoded payload.
+    server.mount_proc("/gzip") do |_req, res|
+      res.content_type = "text/plain"
+      res["content-encoding"] = "gzip"
+      res.body = ProxyTestServer.gzip(GZIP_PLAINTEXT)
+    end
+  end
+
+  GZIP_PLAINTEXT = ("the quick brown fox " * 32).freeze
+
+  def gzip(string)
+    io = StringIO.new
+    io.set_encoding(Encoding::BINARY)
+    writer = Zlib::GzipWriter.new(io)
+    writer.write(string)
+    writer.close
+    io.string
   end
 
   # A self-signed certificate for 127.0.0.1, generated once per run. It is


### PR DESCRIPTION
**Stacked PR 3/7** — base: `modernization/batch-2-security`. Merge the stack in order (1 → 7).

Additive TLS/timeout hardening:

- `:ca_file`/`:cert_store` options + hermetic VERIFY_PEER-success test against a local CA (P1-6)
- `:open_timeout`/`:write_timeout` options on both paths (P2-2)
- `:min_version`/`:max_version` TLS options; `:ssl_version` deprecated but still working (P2-8)
- `rack` dependency constrained (`>= 2.0, < 4`) + explicit `require "rack"` (P1-7)
- `:max_response_length` cap on buffered reads (P2-3)
- Example load safety (P2-5 partial) and a load-time guard on the net/http monkey-patch (P1-5 interim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
