### PR TITLE
Batch 4: Security docs, supply-chain, README overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project aims to
+follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+This entry collects the 2026 modernization + security-hardening work (see
+`MODERNIZATION_PLAN.md`). It is not yet released.
+
+### Security
+
+- Strip hop-by-hop headers from the **forwarded request** (Connection, TE,
+  Transfer-Encoding, Proxy-Authorization, …, plus any header named by the inbound
+  `Connection` header), closing a Content-Length/Transfer-Encoding request-smuggling
+  surface. Hop-by-hop headers were previously stripped only from the response.
+- Add `backend_allowed?(backend)` — an overridable SSRF guardrail. It defaults to
+  allowing any backend (backward compatible); override it to allowlist expected
+  hosts when the destination is derived from the client `Host` header. A refused
+  backend responds `502`.
+- Add `:max_response_length` to cap the backend response size (bounds memory
+  against a hostile/huge backend). Enforced incrementally while streaming.
+- Add `:ca_file` / `:cert_store` so private-CA backends can be verified under the
+  default `VERIFY_PEER` instead of disabling verification.
+- Add `:open_timeout` / `:write_timeout` to bound connect and per-write stalls
+  (previously only `:read_timeout` was configurable).
+
+### Added
+
+- `:min_version` / `:max_version` TLS options (mapping to `Net::HTTP#min_version=`
+  / `#max_version=`). `:ssl_version` still works but is deprecated (it pins an
+  exact protocol and forbids TLS 1.3).
+- `HttpStreamingResponse#close` so Rack servers release the backend connection on
+  early termination (HEAD, 304, client disconnect) instead of leaking it until GC.
+- Project scaffolding: `SECURITY.md`, `CHANGELOG.md`, `CONTRIBUTING.md`,
+  `CLAUDE.md`/`AGENTS.md`, GitHub Actions CI (Ruby 3.1–3.4 × Rack 2/3), Dependabot.
+
+### Changed
+
+- Backend and construction failures now map to status codes instead of raising a
+  `500`: `400` (malformed request URI), `501` (unknown HTTP method), `502`
+  (broadened backend-error set incl. `ECONNRESET`, `EPIPE`, read/write timeouts,
+  `EOFError`, `OpenSSL::SSL::SSLError`, protocol errors).
+- gzip-encoded backend responses are forwarded verbatim (Content-Encoding and
+  Content-Length preserved) instead of being transparently inflated.
+- Skip all `1xx` interim responses (including `103 Early Hints`) on the streaming
+  path, so a backend's `103` is no longer mistaken for the final response.
+- `rack` dependency constrained to `>= 2.0, < 4`; the library now `require`s rack
+  itself.
+- Test suite is fully offline (local WEBrick server); the previous live-host
+  tests are gated behind `LIVE=1`.
+
+### Deprecated
+
+- `:ssl_version` — use `:min_version` / `:max_version`.
+
+## [0.8.3] - 2025
+
+### Fixed
+
+- Handle non-rewindable request body streams (Rack 3 input streams need not
+  respond to `#rewind`). (#128)
+
+## [0.8.2] - 2025
+
+### Fixed
+
+- Harden `build_header_hash` against a top-level `::Headers` constant defined by
+  the host app being picked up instead of `Rack::Headers`.
+
+## [0.8.1] - 2025
+
+### Added
+
+- `:logger` option, wired to `Net::HTTP#set_debug_output` for wire-level debug
+  output. (#80)
+
+## [0.8.0] - 2025
+
+### Changed
+
+- **BREAKING:** TLS certificate verification now defaults to `VERIFY_PEER`
+  (Ruby's `Net::HTTP` default). Previous versions silently used `VERIFY_NONE` for
+  HTTPS backends. Pass `ssl_verify_none: true` (or `verify_mode:`) to opt out. (#113)
+
+### Fixed
+
+- Return `502` on backend connection errors instead of raising; correct body
+  handling for empty responses and no-entity-body statuses (1xx/204/304). (#58, #122, #123)
+
+---
+
+Older releases (≤ 0.7.8) predate this changelog; see the git history and tags.
+
+[Unreleased]: https://github.com/ncr/rack-proxy/compare/v0.8.3...HEAD
+[0.8.3]: https://github.com/ncr/rack-proxy/compare/v0.8.2...v0.8.3
+[0.8.2]: https://github.com/ncr/rack-proxy/compare/v0.8.1...v0.8.2
+[0.8.1]: https://github.com/ncr/rack-proxy/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/ncr/rack-proxy/compare/v0.7.8...v0.8.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to rack-proxy
+
+Thanks for helping improve rack-proxy. It is a small, security-sensitive library,
+so the bar is safe defaults, no surprises, and no regressions of the security
+behavior documented in [`CLAUDE.md`](CLAUDE.md).
+
+## Getting started
+
+```sh
+bundle install
+bundle exec rake test          # full suite, fully OFFLINE, ~0.2s
+```
+
+The default suite never touches the network. To additionally run the real-internet
+smoke tests:
+
+```sh
+LIVE=1 bundle exec rake test
+```
+
+To run against a specific Rack major (CI runs both):
+
+```sh
+BUNDLE_GEMFILE=gemfiles/rack_3.gemfile bundle exec rake test
+BUNDLE_GEMFILE=gemfiles/rack_2.gemfile bundle exec rake test
+```
+
+## Ground rules
+
+- **Read [`CLAUDE.md`](CLAUDE.md) first.** It lists the security invariants (each
+  mapped to its guarding test) and the traps.
+- **Tests must be offline.** Use `with_webrick_proxy` (in
+  `test/rack_proxy_test.rb`) or `ProxyTestServer` (in
+  `test/support/proxy_test_server.rb`). Do not add live-host tests; put anything
+  that genuinely needs the internet behind `ENV["LIVE"]` in
+  `test/live_smoke_test.rb`.
+- **Do not add `webmock` or `vcr`** — they monkey-patch `net/http` and break the
+  streaming code path.
+- **Do not casually refactor `lib/net_http_hacked.rb`.** It depends on private
+  `Net::HTTP` internals; changes there can silently break streaming. The planned
+  replacement is a deliberate Fiber-based rewrite (see `MODERNIZATION_PLAN.md`).
+- **Keep the test framework as `test-unit`.**
+- New behavior needs a regression test; bug fixes should add a test that fails
+  before the fix.
+
+## Pull requests
+
+1. Fork and branch from `master`.
+2. Make the change with tests; keep `bundle exec rake test` green on Rack 2 and 3.
+3. Add a `CHANGELOG.md` entry under `[Unreleased]`.
+4. Open the PR describing the streaming/non-streaming paths affected and the
+   backend scheme, if relevant.
+
+## Reporting security issues
+
+Please do **not** open a public issue. See [`SECURITY.md`](SECURITY.md).
+
+## Releasing (maintainers)
+
+1. Update `lib/rack/proxy/version.rb` and move the `[Unreleased]` changelog entry
+   under the new version.
+2. Tag `vX.Y.Z` and push; the release workflow publishes the gem.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 Jacek Becela jacek.becela@gmail.com
+Copyright (c) 2010-2026 Jacek Becela and contributors jacek.becela@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MODERNIZATION_PLAN.md
+++ b/MODERNIZATION_PLAN.md
@@ -7,10 +7,35 @@
 >   `:ca_file`/`:cert_store` (P1-6, incl. hermetic VERIFY_PEER-success test),
 >   `:open_timeout`/`:write_timeout` (P2-2), `:min_version`/`:max_version` (P2-8),
 >   rack pin + `require "rack"` (P1-7), `:max_response_length` (P2-3), example load
->   safety (P2-5 partial — physical move + README deferred to Batch 4), and a
->   load-time guard on the monkey-patch (P1-5 interim).
-> - **Still open:** P1-5 the Fiber-based rewrite that retires `net_http_hacked.rb`
->   (high-risk, deserves a dedicated pass); Batch 4 (docs, supply-chain, README, polish).
+>   safety (P2-5 partial), and a load-time guard on the monkey-patch (P1-5 interim).
+> - Batch 4 docs & supply-chain — DONE, branch `modernization/batch-4-docs-supply-chain`:
+>   `SECURITY.md` + README "Security considerations" (P1-8), `CHANGELOG.md` +
+>   gemspec metadata/MFA (P1-9), README accuracy overhaul (P2-1), `CONTRIBUTING.md`,
+>   `frozen_string_literal` pragmas (P2-7 partial), LICENSE year.
+>
+> ## Continuation / handoff (read this if resuming on another machine)
+>
+> Four branches are **stacked**, each its own PR — merge in order:
+> `batch-1-green-loop` → `batch-2-security` → `batch-3-tls-timeouts` → `batch-4-docs-supply-chain`.
+> `master` is untouched. Run tests with `bundle exec rake test` (offline, ~0.2s);
+> CI covers Ruby 3.1–3.4 × Rack 2/3. See [`CLAUDE.md`](CLAUDE.md) for invariants/traps.
+>
+> **Decisions locked in:** (1) the P0-4 SSRF `backend_allowed?` default stays
+> allow-all until a **major** version bump; (2) the P1-5 Fiber rewrite is
+> deferred as its own dedicated, heavily-tested pass (not started).
+>
+> **Still open / next up:**
+> - **P1-5** — Fiber-based rewrite retiring `lib/net_http_hacked.rb` (the one
+>   high-risk item; monkey-patch works and is guarded in the meantime).
+> - **P2-7 remainder** — adopt Standard/RuboCop and add a lint + `bundler-audit`
+>   CI job (frozen-string pragmas already landed; a full `--fix` should be its own commit).
+> - **P2-5 remainder** — physically move `lib/rack_proxy_examples/` → `examples/`
+>   and rework the README to copy-paste snippets (deferred so the documented
+>   `require 'rack_proxy_examples/...'` flow keeps working until then).
+> - **P3 polish** — SimpleCov coverage floor, `.github` issue/PR templates,
+>   opt-in credential/XFF stripping conveniences.
+> - When ready to release, bump `lib/rack/proxy/version.rb`, move the CHANGELOG
+>   `[Unreleased]` section under the new version, tag `vX.Y.Z`.
 
 Baseline already in place (do **not** redo): VERIFY_PEER default (proxy.rb:149/158), 502-on-connect-error mapping (proxy.rb:172), Rack 3 `Headers`/Rack 2 `HeaderHash` branch (proxy.rb:44-50), non-rewindable body guard (proxy.rb:131), `:logger` option. Everything below builds on that.
 

--- a/MODERNIZATION_PLAN.md
+++ b/MODERNIZATION_PLAN.md
@@ -1,9 +1,16 @@
 # rack-proxy — 2026 Modernization + Hardening Roadmap
 
-> **Progress:** Batch 1 (green loop) — DONE on branch `modernization/batch-1-green-loop`.
-> Batch 2 (all six P0 security fixes + P1-4 config dedup) — DONE on branch
-> `modernization/batch-2-security`, each with a regression test on the offline harness.
-> Remaining: Batch 3 (modernization & hardening) and Batch 4 (docs, supply-chain, polish).
+> **Progress:**
+> - Batch 1 (green loop) — DONE, branch `modernization/batch-1-green-loop`.
+> - Batch 2 (six P0 security fixes + P1-4 config dedup) — DONE, branch `modernization/batch-2-security`.
+> - Batch 3 additive hardening — DONE, branch `modernization/batch-3-tls-timeouts`:
+>   `:ca_file`/`:cert_store` (P1-6, incl. hermetic VERIFY_PEER-success test),
+>   `:open_timeout`/`:write_timeout` (P2-2), `:min_version`/`:max_version` (P2-8),
+>   rack pin + `require "rack"` (P1-7), `:max_response_length` (P2-3), example load
+>   safety (P2-5 partial — physical move + README deferred to Batch 4), and a
+>   load-time guard on the monkey-patch (P1-5 interim).
+> - **Still open:** P1-5 the Fiber-based rewrite that retires `net_http_hacked.rb`
+>   (high-risk, deserves a dedicated pass); Batch 4 (docs, supply-chain, README, polish).
 
 Baseline already in place (do **not** redo): VERIFY_PEER default (proxy.rb:149/158), 502-on-connect-error mapping (proxy.rb:172), Rack 3 `Headers`/Rack 2 `HeaderHash` branch (proxy.rb:44-50), non-rewindable body guard (proxy.rb:131), `:logger` option. Everything below builds on that.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
+# Rack::Proxy
+
 A request/response rewriting HTTP proxy. A Rack app. Subclass `Rack::Proxy` and provide your `rewrite_env` and `rewrite_response` methods.
+
+## Contents
+
+- [Installation](#installation)
+- [Use Cases](#use-cases)
+- [Options](#options)
+- [Security considerations](#security-considerations)
+- [Examples](#examples)
+- [Upgrading](#upgrading)
+- [A note on header keys](#a-note-on-header-keys-96)
+- [Compatibility notes](#compatibility-notes)
 
 Installation
 ----
@@ -36,20 +49,63 @@ Options
 
 Options can be set when initializing the middleware or overriding a method.
 
+* `:streaming` - stream the backend response as it arrives (default `true`). Set to `false` to buffer the whole response before returning it (also required under `webmock`/`vcr` — see [Compatibility notes](#compatibility-notes)).
+* `:backend` - URI (or URI-parseable string) of the backend host/port/scheme to proxy to. If not set, the destination is derived from the incoming request's `Host` — see [Security considerations](#security-considerations).
+* `:read_timeout` - per-read timeout in seconds (default `60`).
+* `:open_timeout` - connection-open timeout in seconds.
+* `:write_timeout` - per-write timeout in seconds.
+* `:ssl_verify_none` - skip TLS certificate verification. Verification is on by default (`VERIFY_PEER`) — see [Upgrading](#upgrading).
+* `:verify_mode` - explicit `OpenSSL::SSL::VERIFY_*` constant; wins over `ssl_verify_none`.
+* `:ca_file` - path to a PEM CA bundle used to verify the backend certificate (prefer this over disabling verification for private CAs).
+* `:cert_store` - an `OpenSSL::X509::Store` used to verify the backend certificate.
+* `:cert` / `:key` - client certificate and key for mutual TLS to the backend.
+* `:min_version` / `:max_version` - TLS protocol range (e.g. `:TLS1_2`), mapped to `Net::HTTP#min_version=` / `#max_version=`.
+* `:ssl_version` - **deprecated**; pins an exact protocol (forbids TLS 1.3). Use `:min_version` / `:max_version`.
+* `:max_response_length` - cap (in bytes) on the backend response size; a larger response is refused with `502` (streaming aborts once the cap is passed).
+* `:username` / `:password` - HTTP Basic credentials sent to the backend.
+* `:logger` - any object responding to `#<<` (e.g. `$stdout`, a `StringIO`, or a Ruby `Logger`). Wired to `Net::HTTP#set_debug_output` so the HTTP wire-level conversation is written to the sink. Useful for debugging.
 
-* `:streaming` - defaults to `true`, but does not work on all Ruby versions, recommend to set to `false`
-* `:ssl_verify_none` - tell `Net::HTTP` to skip TLS certificate verification (defaults to verifying — see [Upgrading](#upgrading) for the 0.8 change)
-* `:verify_mode` - explicit `OpenSSL::SSL::VERIFY_*` constant; wins over `ssl_verify_none`
-* `:ssl_version` - tell `Net::HTTP` to set a specific `ssl_version`
-* `:backend` - the URI parseable format of host and port of the target proxy backend. If not set it will assume the backend target is the same as the source.
-* `:read_timeout` - set proxy timeout it defaults to 60 seconds
-* `:logger` - any object responding to `#<<` (e.g. `$stdout`, a `StringIO`, or a Ruby `Logger`). Wired through to `Net::HTTP#set_debug_output` so the full HTTP wire-level conversation is written to the sink. Useful for debugging.
+Two request-scoped overrides can also be set in `env` (e.g. from `rewrite_env`):
+
+* `env['rack.backend']` - a URI overriding `:backend` for this request.
+* `env['http.read_timeout']` - override `:read_timeout` for this request.
 
 To pass in options, when you configure your middleware you can pass them in as an optional hash.
 
 ```ruby
 Rails.application.config.middleware.use ExampleServiceProxy, backend: 'http://guides.rubyonrails.org', streaming: false
 ```
+
+Security considerations
+----
+
+rack-proxy forwards attacker-influenced requests to a backend and relays the backend's response. Configure and subclass it with that in mind.
+
+* **SSRF / open proxy.** If you do **not** set `:backend`, the destination host/port/scheme is derived from the incoming request's `Host` / `X-Forwarded-Host` header. A bare `Rack::Proxy.new` will therefore proxy to *any* host a client names — including cloud metadata endpoints (`169.254.169.254`), loopback, and private ranges. Either set a fixed `:backend`, or override `backend_allowed?(backend)` to allowlist expected hosts:
+
+    ```ruby
+    class MyProxy < Rack::Proxy
+      ALLOWED = %w[api.internal.example.com].freeze
+
+      def backend_allowed?(backend)
+        ALLOWED.include?(backend.host)
+      end
+    end
+    ```
+
+    A refused backend is answered with `502`. (Making dynamic, `Host`-derived backends opt-in by default is planned for a future major version.)
+
+* **Credential forwarding.** All incoming `HTTP_*` headers are forwarded, including `Authorization` and `Cookie`. Don't proxy to a different trust domain with credentials attached; strip them in `rewrite_env` (e.g. `env['HTTP_COOKIE'] = ''`). Over an `http://` backend these travel in cleartext.
+
+* **X-Forwarded-For.** rack-proxy appends `REMOTE_ADDR` to any inbound `X-Forwarded-For`. If your clients are not behind a trusted proxy, the inbound value is attacker-controlled; sanitize it in `rewrite_env` when the backend trusts that header.
+
+* **TLS verification** defaults to `VERIFY_PEER`. For private-CA backends use `:ca_file` / `:cert_store` rather than `ssl_verify_none: true`.
+
+* **Resource limits.** Use `:max_response_length` plus `:open_timeout` / `:write_timeout` / `:read_timeout` to bound memory and stalls against a hostile or slow backend.
+
+* **Hop-by-hop headers** (Connection, TE, Transfer-Encoding, Proxy-Authorization, …) are stripped from both the forwarded request and the response.
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 Examples
 ----
@@ -132,7 +188,7 @@ Test with `require 'rack_proxy_examples/example_service_proxy'`
 # 1. rails new test_app
 # 2. cd test_app
 # 3. install Rack-Proxy in `Gemfile`
-#    a. `gem 'rack-proxy', '~> 0.7.7'`
+#    a. `gem 'rack-proxy', '~> 0.8.0'`
 # 4. install gem: `bundle install`
 # 5. create `config/initializers/proxy.rb` adding this line `require 'rack_proxy_examples/example_service_proxy'`
 # 6. run: `SERVICE_URL=http://guides.rubyonrails.org rails server`
@@ -307,7 +363,7 @@ key_raw = File.read('./certs/key.pem')
 cert = OpenSSL::X509::Certificate.new(cert_raw)
 key = OpenSSL::PKey.read(key_raw)
 
-use TLSProxy, cert: cert, key: key, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_PEER, ssl_version: 'TLSv1_2'
+use TLSProxy, cert: cert, key: key, verify_mode: OpenSSL::SSL::VERIFY_PEER, min_version: :TLS1_2
 ```
 
 And rewrite host for example:
@@ -346,14 +402,7 @@ Per the standard Rack/CGI convention, header names received by your proxy are ex
 
 If you need underscore-style headers preserved end-to-end, configure your fronting web server (e.g. `underscores_in_headers on;` in nginx, or `HTTPProtocolOptions` in Apache) — rack-proxy is not the right layer to fix this.
 
-WARNING
+Compatibility notes
 ----
 
-Doesn't work with `fakeweb`/`webmock`. Both libraries monkey-patch net/http code.
-
-Todos
-----
-
-* Make the docs up to date with the current use case for this code: everything except streaming which involved a rather ugly monkey patch and only worked in 1.8, but does not work now.
-* Improve and validate requirements for Host and Path rewrite rules
-* Ability to inject logger and set log level
+The streaming response path (the default) reads directly from `Net::HTTP`, so it does not work under `webmock`, `vcr`, or `fakeweb`, which monkey-patch `net/http`. If you use those libraries in your tests, set `streaming: false`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+`rack-proxy` is a request/response-rewriting HTTP proxy. Because it forwards
+attacker-influenced requests to a backend and relays the backend's response, how
+you configure and subclass it has direct security consequences. Please read the
+threat model below alongside the "Security considerations" section of the README.
+
+## Supported versions
+
+Security fixes are released for the latest `0.x` minor series. Older versions are
+not maintained — please upgrade before reporting.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.8.x   | ✅        |
+| < 0.8   | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately through GitHub's **Report a vulnerability** button under the
+repository's *Security* tab (Private Vulnerability Reporting). If that is
+unavailable to you, email the maintainer at **jacek.becela@gmail.com** with
+`[rack-proxy security]` in the subject.
+
+Please include:
+
+- the rack-proxy, Rack, and Ruby versions,
+- whether you run in streaming (`streaming: true`, the default) or non-streaming mode,
+- a minimal `config.ru` / subclass that reproduces the issue,
+- the impact you observed.
+
+We aim to acknowledge a report within **5 business days** and to agree on a
+disclosure timeline from there. We are grateful for responsible disclosure and
+will credit reporters who want it.
+
+## Scope
+
+In scope: defects in the library itself — for example, credentials or hop-by-hop
+headers being forwarded when they should not be, request/response smuggling,
+verification defaults that are weaker than documented, or a crash/`500` where a
+`4xx`/`5xx` mapping is expected.
+
+Out of scope: insecure **configuration or subclassing** of the library. In
+particular, deriving the backend from a client-controlled `Host` header without
+an allowlist is an SSRF/open-proxy risk that is the deployer's responsibility to
+prevent — see `backend_allowed?` and the README. If the documentation is what led
+you astray, that is in scope: tell us and we will fix the docs.

--- a/lib/net_http_hacked.rb
+++ b/lib/net_http_hacked.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # We are hacking net/http to change semantics of streaming handling
 # from "block" semantics to regular "return" semantics.
 # We need it to construct a streamable rack triplet:

--- a/lib/net_http_hacked.rb
+++ b/lib/net_http_hacked.rb
@@ -91,3 +91,16 @@ class Net::HTTPResponse
     @socket = nil
   end
 end
+
+# Fail loudly (a warning, so non-streaming users are unaffected) if a future
+# net/http drops the private internals this patch reaches into, instead of
+# breaking mysteriously at request time. The planned Fiber-based rewrite (see
+# MODERNIZATION_PLAN.md P1-5) removes this dependency entirely.
+_rack_proxy_missing_net_http = %i[begin_transport end_transport edit_path].reject do |m|
+  Net::HTTP.private_method_defined?(m) || Net::HTTP.method_defined?(m)
+end
+_rack_proxy_missing_net_http << :read_new unless Net::HTTPResponse.respond_to?(:read_new, true)
+unless _rack_proxy_missing_net_http.empty?
+  warn "net_http_hacked: Net::HTTP internals #{_rack_proxy_missing_net_http.join(', ')} are " \
+       "missing on Ruby #{RUBY_VERSION}; Rack::Proxy streaming may be broken. Use streaming: false."
+end

--- a/lib/rack-proxy.rb
+++ b/lib/rack-proxy.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "rack/proxy"

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -12,8 +12,13 @@ module Rack
 
     attr_accessor :use_ssl, :verify_mode, :read_timeout, :ssl_version, :cert, :key, :logger
 
-    def initialize(request, host, port = nil)
-      @request, @host, @port = request, host, port
+    # An optional block receives the Net::HTTP instance for configuration before
+    # it connects — this is the single source of truth used by Rack::Proxy (see
+    # Rack::Proxy#configure_backend_connection). When no block is given, the
+    # public accessors above are applied instead (backward-compatible path for
+    # direct users of this class).
+    def initialize(request, host, port = nil, &configure)
+      @request, @host, @port, @configure = request, host, port, configure
     end
 
     def body
@@ -68,13 +73,17 @@ module Rack
     # Net::HTTP
     def session
       @session ||= Net::HTTP.new(host, port).tap do |http|
-        http.use_ssl = use_ssl
-        http.verify_mode = verify_mode
-        http.read_timeout = read_timeout
-        http.ssl_version = ssl_version if ssl_version
-        http.cert = cert if cert
-        http.key = key if key
-        http.set_debug_output(logger) if logger
+        if @configure
+          @configure.call(http)
+        else
+          http.use_ssl = use_ssl
+          http.verify_mode = verify_mode
+          http.read_timeout = read_timeout
+          http.ssl_version = ssl_version if ssl_version
+          http.cert = cert if cert
+          http.key = key if key
+          http.set_debug_output(logger) if logger
+        end
         http.start
       end
     end

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "net_http_hacked"
 require "stringio"
 

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -4,6 +4,10 @@ require "stringio"
 module Rack
   # Wraps the hacked net/http in a Rack way.
   class HttpStreamingResponse
+    # Raised while streaming when the backend body exceeds max_response_length.
+    # The status/headers are already sent, so the transfer is aborted mid-stream.
+    class ResponseTooLarge < StandardError; end
+
     STATUSES_WITH_NO_ENTITY_BODY = {
       204 => true,
       205 => true,
@@ -11,6 +15,7 @@ module Rack
     }.freeze
 
     attr_accessor :use_ssl, :verify_mode, :read_timeout, :ssl_version, :cert, :key, :logger
+    attr_accessor :max_response_length
 
     # An optional block receives the Net::HTTP instance for configuration before
     # it connects — this is the single source of truth used by Rack::Proxy (see
@@ -41,7 +46,16 @@ module Rack
     def each(&block)
       return if connection_closed
 
-      response.read_body(&block)
+      bytes = 0
+      response.read_body do |chunk|
+        if max_response_length
+          bytes += chunk.bytesize
+          if bytes > max_response_length
+            raise ResponseTooLarge, "backend response exceeded max_response_length=#{max_response_length}"
+          end
+        end
+        block.call(chunk)
+      end
     rescue StandardError => e
       # The status/headers are already on the wire, so we can't turn a mid-stream
       # backend failure into a 502. Log it and re-raise so the server aborts the

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rack"
 require "net_http_hacked"
 require "rack/http_streaming_response"

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -1,3 +1,4 @@
+require "rack"
 require "net_http_hacked"
 require "rack/http_streaming_response"
 require "rack/proxy/version"
@@ -97,9 +98,22 @@ module Rack
       @streaming = opts.fetch(:streaming, true)
       @backend = opts[:backend] ? URI(opts[:backend]) : nil
       @read_timeout = opts.fetch(:read_timeout, 60)
+      # Connect and per-write deadlines. Without these a slow/hostile backend can
+      # stall a thread for Net::HTTP's 60s defaults even with a small read_timeout.
+      @open_timeout = opts[:open_timeout]
+      @write_timeout = opts[:write_timeout]
+      # :ssl_version pins an exact protocol and is deprecated (it forbids TLS 1.3);
+      # prefer :min_version / :max_version, which map to Net::HTTP#min_version=/#max_version=.
       @ssl_version = opts[:ssl_version]
+      @min_version = opts[:min_version]
+      @max_version = opts[:max_version]
       @cert = opts[:cert]
       @key = opts[:key]
+      # Trust anchors for VERIFY_PEER: :ca_file is a PEM bundle path, :cert_store
+      # an OpenSSL::X509::Store. Use these for private-CA backends instead of
+      # disabling verification with ssl_verify_none.
+      @ca_file = opts[:ca_file]
+      @cert_store = opts[:cert_store]
       # SSL verification: defaults to VERIFY_PEER (Ruby's Net::HTTP default).
       # Pass ssl_verify_none: true to explicitly disable cert verification, or
       # pass verify_mode: <OpenSSL::SSL::VERIFY_*> for full control.
@@ -190,13 +204,13 @@ module Rack
 
         if @streaming
           # streaming response (the actual network communication is deferred, a.k.a. streamed)
-          target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port)
-          configure_backend_connection(target_response, use_ssl: use_ssl, read_timeout: read_timeout)
+          target_response = HttpStreamingResponse.new(target_request, backend.host, backend.port) do |http|
+            configure_backend_connection(http, use_ssl: use_ssl, read_timeout: read_timeout)
+          end
           target_response.logger = @logger if @logger
         else
           http = Net::HTTP.new(backend.host, backend.port)
           configure_backend_connection(http, use_ssl: use_ssl, read_timeout: read_timeout)
-          http.set_debug_output(@logger) if @logger
 
           target_response = http.start do
             http.request(target_request)
@@ -235,16 +249,27 @@ module Rack
       nil
     end
 
-    # Single source of truth for TLS/timeout setup, applied identically to both
-    # the streaming response and the non-streaming Net::HTTP connection so a TLS
-    # option (notably the VERIFY_PEER default) can never land on only one path.
+    # Single source of truth for TLS/timeout setup, applied to the (real
+    # Net::HTTP) connection on both the streaming and non-streaming paths so a
+    # TLS option — notably the VERIFY_PEER default — can never land on only one.
     def configure_backend_connection(conn, use_ssl:, read_timeout:)
       conn.use_ssl = use_ssl
       conn.read_timeout = read_timeout
-      conn.ssl_version = @ssl_version if @ssl_version
-      conn.verify_mode = (@verify_mode || OpenSSL::SSL::VERIFY_PEER) if use_ssl
-      conn.cert = @cert if @cert
-      conn.key = @key if @key
+      conn.open_timeout = @open_timeout if @open_timeout
+      conn.write_timeout = @write_timeout if @write_timeout
+
+      if use_ssl
+        conn.verify_mode = @verify_mode || OpenSSL::SSL::VERIFY_PEER
+        conn.ca_file = @ca_file if @ca_file
+        conn.cert_store = @cert_store if @cert_store
+        conn.min_version = @min_version if @min_version
+        conn.max_version = @max_version if @max_version
+        conn.ssl_version = @ssl_version if @ssl_version # deprecated; prefer min/max_version
+        conn.cert = @cert if @cert
+        conn.key = @key if @key
+      end
+
+      conn.set_debug_output(@logger) if @logger
       conn
     end
   end

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -102,6 +102,10 @@ module Rack
       # stall a thread for Net::HTTP's 60s defaults even with a small read_timeout.
       @open_timeout = opts[:open_timeout]
       @write_timeout = opts[:write_timeout]
+      # Optional cap (in bytes) on the backend response size, to bound memory
+      # against a hostile/huge backend. Enforced incrementally while streaming and
+      # via the declared Content-Length / buffered size otherwise. Default: no cap.
+      @max_response_length = opts[:max_response_length]
       # :ssl_version pins an exact protocol and is deprecated (it forbids TLS 1.3);
       # prefer :min_version / :max_version, which map to Net::HTTP#min_version=/#max_version=.
       @ssl_version = opts[:ssl_version]
@@ -236,10 +240,37 @@ module Rack
       # consistent on Rack 2 for any downstream middleware.
       headers.keys.each { |k| headers.delete(k) if HOP_BY_HOP_HEADERS[k.downcase] }
 
+      return [502, {}, []] if response_too_large?(target_response, headers, body)
+
       [code, headers, body]
     end
 
     private
+
+    # Enforce :max_response_length. Returns true (→ 502) when the response is
+    # already known to be too large. For streaming, a declared oversize is
+    # rejected up-front (the connection is closed) and the incremental limit is
+    # armed on the body for chunked/unknown-length responses; for non-streaming,
+    # the body is already buffered so we check its actual size. Returns false
+    # (allow) when no cap is set.
+    def response_too_large?(target_response, headers, body)
+      return false unless @max_response_length
+
+      declared = headers['Content-Length']
+      declared_oversize = declared && declared.to_i > @max_response_length
+
+      if target_response.respond_to?(:max_response_length=)
+        if declared_oversize
+          target_response.close
+          return true
+        end
+        target_response.max_response_length = @max_response_length
+        false
+      else
+        buffered = body.sum { |part| part.to_s.bytesize }
+        declared_oversize || buffered > @max_response_length
+      end
+    end
 
     # Resolve the Net::HTTP request class for an HTTP method, or nil if there is
     # no matching Net::HTTP::<Verb> (unknown/unsupported method -> 501).

--- a/lib/rack_proxy_examples/example_service_proxy.rb
+++ b/lib/rack_proxy_examples/example_service_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # This is an example of how to use Rack-Proxy in a Rails application.
 #

--- a/lib/rack_proxy_examples/example_service_proxy.rb
+++ b/lib/rack_proxy_examples/example_service_proxy.rb
@@ -37,4 +37,9 @@ class ExampleServiceProxy < Rack::Proxy
   end
 end
 
-Rails.application.config.middleware.use ExampleServiceProxy, backend: ENV['SERVICE_URL'], streaming: false
+# Only wire into the middleware stack when running inside a booted Rails app, so
+# this file is safe to require anywhere (doc/RBI tooling, a stray require) without
+# crashing or silently installing a proxy.
+if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+  Rails.application.config.middleware.use ExampleServiceProxy, backend: ENV['SERVICE_URL'], streaming: false
+end

--- a/lib/rack_proxy_examples/forward_host.rb
+++ b/lib/rack_proxy_examples/forward_host.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ForwardHost < Rack::Proxy
 
   def rewrite_env(env)

--- a/lib/rack_proxy_examples/forward_host.rb
+++ b/lib/rack_proxy_examples/forward_host.rb
@@ -21,4 +21,7 @@ class ForwardHost < Rack::Proxy
 
 end
 
-Rails.application.config.middleware.use ForwardHost, backend: 'http://example.com', streaming: false
+# Only wire into the middleware stack when running inside a booted Rails app.
+if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+  Rails.application.config.middleware.use ForwardHost, backend: 'http://example.com', streaming: false
+end

--- a/lib/rack_proxy_examples/rack_php_proxy.rb
+++ b/lib/rack_proxy_examples/rack_php_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Open http://localhost:3000/test.php to trigger proxy
 ###

--- a/lib/rack_proxy_examples/rack_php_proxy.rb
+++ b/lib/rack_proxy_examples/rack_php_proxy.rb
@@ -34,4 +34,7 @@ class RackPhpProxy < Rack::Proxy
   end
 end
 
-Rails.application.config.middleware.use RackPhpProxy, backend: ENV["HTTP_HOST"]='http://php.net', streaming: false
+# Only wire into the middleware stack when running inside a booted Rails app.
+if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+  Rails.application.config.middleware.use RackPhpProxy, backend: 'http://php.net', streaming: false
+end

--- a/lib/rack_proxy_examples/trusting_proxy.rb
+++ b/lib/rack_proxy_examples/trusting_proxy.rb
@@ -19,7 +19,10 @@ class TrustingProxy < Rack::Proxy
 end
 
 # Pass ssl_verify_none: true to skip TLS certificate verification.
-Rails.application.config.middleware.use TrustingProxy,
-  backend: 'https://self-signed.badssl.com',
-  streaming: false,
-  ssl_verify_none: true
+# Only wire into the middleware stack when running inside a booted Rails app.
+if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+  Rails.application.config.middleware.use TrustingProxy,
+    backend: 'https://self-signed.badssl.com',
+    streaming: false,
+    ssl_verify_none: true
+end

--- a/lib/rack_proxy_examples/trusting_proxy.rb
+++ b/lib/rack_proxy_examples/trusting_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TrustingProxy < Rack::Proxy
 
   def rewrite_env(env)

--- a/rack-proxy.gemspec
+++ b/rack-proxy.gemspec
@@ -14,7 +14,14 @@ Gem::Specification.new do |s|
   s.description = %q{A Rack app that provides request/response rewriting proxy capabilities with streaming.}
   s.required_ruby_version = ">= 3.0"
 
-  s.files = Dir["lib/**/*.rb"] + %w[README.md LICENSE rack-proxy.gemspec]
+  s.metadata = {
+    "source_code_uri"       => "https://github.com/ncr/rack-proxy",
+    "changelog_uri"         => "https://github.com/ncr/rack-proxy/blob/master/CHANGELOG.md",
+    "bug_tracker_uri"       => "https://github.com/ncr/rack-proxy/issues",
+    "rubygems_mfa_required" => "true"
+  }
+
+  s.files = Dir["lib/**/*.rb"] + %w[README.md LICENSE CHANGELOG.md SECURITY.md rack-proxy.gemspec]
   s.require_paths = ["lib"]
 
   s.add_dependency("rack", ">= 2.0", "< 4")

--- a/rack-proxy.gemspec
+++ b/rack-proxy.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + %w[README.md LICENSE rack-proxy.gemspec]
   s.require_paths = ["lib"]
 
-  s.add_dependency("rack")
+  s.add_dependency("rack", ">= 2.0", "< 4")
   s.add_development_dependency("rack-test")
   s.add_development_dependency("test-unit")
   s.add_development_dependency("webrick")

--- a/test/examples_test.rb
+++ b/test/examples_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+require "rack/proxy"
+
+# The bundled examples ship on the gem load path, so they must be safe to
+# require outside a Rails app: no crash and no side effect (they only wire
+# themselves into the middleware stack when Rails is booted). This guards
+# doc/RBI tooling and stray requires.
+class ExamplesTest < Test::Unit::TestCase
+  EXAMPLES = {
+    "rack_proxy_examples/forward_host"          => "ForwardHost",
+    "rack_proxy_examples/rack_php_proxy"        => "RackPhpProxy",
+    "rack_proxy_examples/trusting_proxy"        => "TrustingProxy",
+    "rack_proxy_examples/example_service_proxy" => "ExampleServiceProxy"
+  }.freeze
+
+  def test_examples_are_safe_to_require_without_rails
+    assert !defined?(Rails), "this test assumes Rails is not loaded"
+
+    EXAMPLES.each do |path, class_name|
+      assert_nothing_raised("requiring #{path} outside Rails must not raise") do
+        require path
+      end
+      assert Object.const_defined?(class_name), "#{class_name} should be defined after requiring #{path}"
+      assert Object.const_get(class_name).ancestors.include?(Rack::Proxy),
+        "#{class_name} should subclass Rack::Proxy"
+    end
+  end
+end

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -55,8 +55,10 @@ class RackProxyTest < Test::Unit::TestCase
     end
   end
 
+  # Uses the modern :min_version option (:ssl_version is deprecated). The other
+  # _tls test below still exercises :ssl_version for backward compatibility.
   def test_https_streaming_tls
-    with_webrick_proxy(ssl: true, ssl_verify_none: true, ssl_version: :TLSv1_2) do |port, proxy|
+    with_webrick_proxy(ssl: true, ssl_verify_none: true, min_version: :TLS1_2) do |port, proxy|
       proxy.host = "127.0.0.1:#{port}"
       get 'https://example.com'
       assert last_response.ok?
@@ -320,6 +322,58 @@ class RackProxyTest < Test::Unit::TestCase
     end
   end
 
+  # P1-6: with a :ca_file that trusts the backend's CA, the default VERIFY_PEER
+  # must *accept* the (otherwise-untrusted) cert. This is the keystone hermetic
+  # VERIFY_PEER-success test that previously required a live host.
+  def test_https_ca_file_accepts_trusted_cert_non_streaming
+    with_webrick_proxy(ssl: true, ca_signed: true, streaming: false, ca_file: ProxyTestServer.ca_file) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get 'https://example.com/'
+      assert last_response.ok?, 'VERIFY_PEER must accept a cert signed by the configured ca_file'
+      assert_match(/Example Domain/, last_response.body)
+    end
+  end
+
+  def test_https_ca_file_accepts_trusted_cert_streaming
+    with_webrick_proxy(ssl: true, ca_signed: true, streaming: true, ca_file: ProxyTestServer.ca_file) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get 'https://example.com/'
+      assert last_response.ok?
+      assert_match(/Example Domain/, last_response.body)
+    end
+  end
+
+  # Without the ca_file, the same CA-signed cert is untrusted and must be rejected
+  # (-> 502), proving the ca_file is what establishes trust.
+  def test_https_ca_signed_cert_rejected_without_ca_file
+    with_webrick_proxy(ssl: true, ca_signed: true, streaming: false) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get 'https://example.com/'
+      assert_equal 502, last_response.status
+    end
+  end
+
+  # P2-2: :open_timeout / :write_timeout must be wired onto the connection
+  # (Net::HTTP defaults them to 60s, unreachable via :read_timeout alone).
+  def test_connect_and_write_timeouts_are_applied
+    proxy = Rack::Proxy.new(read_timeout: 5, open_timeout: 3, write_timeout: 7)
+    http = Net::HTTP.new("127.0.0.1", 80)
+    proxy.send(:configure_backend_connection, http, use_ssl: false, read_timeout: 5)
+    assert_equal 5, http.read_timeout
+    assert_equal 3, http.open_timeout
+    assert_equal 7, http.write_timeout
+  end
+
+  # P1-6: :ca_file / :cert_store must be wired onto the TLS connection.
+  def test_ca_file_and_cert_store_are_applied
+    store = OpenSSL::X509::Store.new
+    proxy = Rack::Proxy.new(ca_file: "/tmp/some-ca.pem", cert_store: store)
+    http = Net::HTTP.new("127.0.0.1", 443)
+    proxy.send(:configure_backend_connection, http, use_ssl: true, read_timeout: 5)
+    assert_equal "/tmp/some-ca.pem", http.ca_file
+    assert_same store, http.cert_store
+  end
+
   # Issue #80: a :logger option should pipe Net::HTTP debug output to the
   # given sink (anything responding to #<<). We use a StringIO to capture it.
   def test_logger_captures_request_in_non_streaming
@@ -508,8 +562,8 @@ class RackProxyTest < Test::Unit::TestCase
   # the network. Pass ssl: true for an HTTPS backend with a self-signed cert; all
   # other keyword options are forwarded to the proxy (e.g. streaming:,
   # ssl_verify_none:, ssl_version:, logger:).
-  def with_webrick_proxy(ssl: false, **proxy_opts)
-    server, port = ProxyTestServer.start_server(ssl: ssl)
+  def with_webrick_proxy(ssl: false, ca_signed: false, **proxy_opts)
+    server, port = ProxyTestServer.start_server(ssl: ssl, ca_signed: ca_signed)
 
     proxy = HostProxy.new(**proxy_opts)
     @app = proxy

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -505,6 +505,43 @@ class RackProxyTest < Test::Unit::TestCase
     @app = nil
   end
 
+  # P2-3: :max_response_length caps the backend response size.
+  def test_max_response_length_rejects_declared_oversize_non_streaming
+    with_webrick_proxy(streaming: false, max_response_length: 10) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get "/" # body is well over 10 bytes, with a Content-Length
+      assert_equal 502, last_response.status
+    end
+  end
+
+  def test_max_response_length_rejects_declared_oversize_streaming
+    with_webrick_proxy(streaming: true, max_response_length: 10) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get "/"
+      assert_equal 502, last_response.status
+    end
+  end
+
+  # No Content-Length (chunked): the cap must still fire incrementally while
+  # streaming, aborting the transfer with ResponseTooLarge.
+  def test_max_response_length_enforced_while_streaming_chunked
+    with_webrick_proxy(streaming: true, max_response_length: 5) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      status, _headers, body = proxy.call(Rack::MockRequest.env_for("/chunked"))
+      assert_equal 200, status.to_i, "headers precede the body, so status is still 200"
+      assert_raise(Rack::HttpStreamingResponse::ResponseTooLarge) { body.each { |_chunk| } }
+    end
+  end
+
+  def test_max_response_length_allows_within_limit
+    with_webrick_proxy(streaming: false, max_response_length: 100_000) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get "/"
+      assert last_response.ok?
+      assert_match(/Example Domain/, last_response.body)
+    end
+  end
+
   private
 
   def assert_gzip_forwarded_verbatim(streaming:)

--- a/test/support/proxy_test_server.rb
+++ b/test/support/proxy_test_server.rb
@@ -5,6 +5,7 @@ require "webrick/https"
 require "socket"
 require "stringio"
 require "zlib"
+require "tempfile"
 
 # A tiny local WEBrick server with a fixed set of routes, used across the whole
 # test suite so tests never touch the public internet. This is the ONLY approved
@@ -25,9 +26,12 @@ module ProxyTestServer
   module_function
 
   # Starts a server on an ephemeral port bound to 127.0.0.1 and returns
-  # [server, port]. Pass ssl: true for HTTPS with an auto-generated self-signed
-  # certificate (untrusted on purpose — it exercises the VERIFY_PEER default).
-  def start_server(ssl: false)
+  # [server, port]. Pass ssl: true for HTTPS. By default the cert is self-signed
+  # (untrusted on purpose — exercises the VERIFY_PEER default rejecting it). Pass
+  # ca_signed: true for a cert signed by ProxyTestServer.ca_file's CA, so a proxy
+  # configured with that ca_file verifies successfully (the VERIFY_PEER *success*
+  # path, offline).
+  def start_server(ssl: false, ca_signed: false)
     options = {
       Port: 0,
       BindAddress: "127.0.0.1",
@@ -36,7 +40,7 @@ module ProxyTestServer
     }
 
     if ssl
-      cert, key = self_signed_cert
+      cert, key = ca_signed ? ca_signed_cert : self_signed_cert
       options[:SSLEnable]      = true
       options[:SSLCertificate] = cert
       options[:SSLPrivateKey]  = key
@@ -125,6 +129,71 @@ module ProxyTestServer
       cert.sign(key, OpenSSL::Digest.new("SHA256"))
 
       [cert, key]
+    end
+  end
+
+  # A test certificate authority, generated once per run. Its cert (in PEM form
+  # at #ca_file) can be handed to a proxy as :ca_file so it trusts #ca_signed_cert.
+  def certificate_authority
+    @certificate_authority ||= begin
+      key = OpenSSL::PKey::RSA.new(2048)
+      cert = OpenSSL::X509::Certificate.new
+      name = OpenSSL::X509::Name.parse("/CN=rack-proxy-test-ca")
+      cert.version    = 2
+      cert.serial     = 1
+      cert.subject    = name
+      cert.issuer     = name
+      cert.public_key = key.public_key
+      cert.not_before = Time.now - 3600
+      cert.not_after  = Time.now + (365 * 24 * 3600)
+
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = cert
+      ef.issuer_certificate  = cert
+      cert.add_extension(ef.create_extension("basicConstraints", "CA:TRUE", true))
+      cert.add_extension(ef.create_extension("keyUsage", "keyCertSign, cRLSign", true))
+      cert.sign(key, OpenSSL::Digest.new("SHA256"))
+
+      [cert, key]
+    end
+  end
+
+  # A 127.0.0.1 leaf certificate signed by #certificate_authority (SAN included),
+  # so default VERIFY_PEER accepts it when the proxy is given #ca_file.
+  def ca_signed_cert
+    @ca_signed_cert ||= begin
+      ca_cert, ca_key = certificate_authority
+      key = OpenSSL::PKey::RSA.new(2048)
+      cert = OpenSSL::X509::Certificate.new
+      cert.version    = 2
+      cert.serial     = 2
+      cert.subject    = OpenSSL::X509::Name.parse("/CN=127.0.0.1")
+      cert.issuer     = ca_cert.subject
+      cert.public_key = key.public_key
+      cert.not_before = Time.now - 3600
+      cert.not_after  = Time.now + (365 * 24 * 3600)
+
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = cert
+      ef.issuer_certificate  = ca_cert
+      cert.add_extension(ef.create_extension("basicConstraints", "CA:FALSE", true))
+      cert.add_extension(ef.create_extension("subjectAltName", "IP:127.0.0.1,DNS:localhost", false))
+      cert.sign(ca_key, OpenSSL::Digest.new("SHA256"))
+
+      [cert, key]
+    end
+  end
+
+  # Path to a PEM file containing the test CA cert. The Tempfile is held in a
+  # module ivar so it isn't unlinked by GC for the life of the process.
+  def ca_file
+    @ca_file ||= begin
+      ca_cert, _ = certificate_authority
+      file = Tempfile.new(["rack-proxy-test-ca", ".pem"])
+      file.write(ca_cert.to_pem)
+      file.flush
+      @ca_file_tempfile = file # keep a reference alive
+      file.path
     end
   end
 


### PR DESCRIPTION
**Stacked PR 4/7** — base: `modernization/batch-3-tls-timeouts`. Merge the stack in order (1 → 7).

Docs and supply-chain batch:

- `SECURITY.md` threat model + README "Security considerations" section (P1-8)
- `CHANGELOG.md` (Keep a Changelog, backfilled 0.8.0–0.8.3) + gemspec metadata block incl. `rubygems_mfa_required` (P1-9)
- README accuracy overhaul: H1/TOC, stale pin fixed, phantom options removed, missing options documented, false streaming warnings deleted (P2-1)
- `CONTRIBUTING.md`, `frozen_string_literal` pragmas (P2-7 partial), LICENSE year refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)
