### PR TITLE
Batch 5: Fiber-based streaming, retiring the net_http_hacked monkey-patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,22 @@ This entry collects the 2026 modernization + security-hardening work (see
 
 ### Changed
 
+- **The streaming path no longer monkey-patches `net/http`.**
+  `Rack::HttpStreamingResponse` now runs the public block form of
+  `Net::HTTP#request` inside a Fiber (pausing at the response head, resuming
+  per body chunk), replacing the 2010-era patch of private `net/http` internals
+  in `net_http_hacked.rb`. Behavioral notes: the streaming session sets
+  `max_retries = 0` so a transport error can never silently replay the request
+  mid-stream; early termination (client abort, HEAD, 204/304) now closes
+  the backend connection immediately instead of draining the remaining body;
+  and a body-less POST/PUT/PATCH on the streaming path now carries
+  `Content-Length: 0` (matching the non-streaming path and plain `Net::HTTP` —
+  the old patched path sent no `Content-Length` at all).
 - Backend and construction failures now map to status codes instead of raising a
   `500`: `400` (malformed request URI), `501` (unknown HTTP method), `502`
   (broadened backend-error set incl. `ECONNRESET`, `EPIPE`, read/write timeouts,
-  `EOFError`, `OpenSSL::SSL::SSLError`, protocol errors).
+  `EOFError`, `OpenSSL::SSL::SSLError`, protocol errors, and malformed backend
+  responses — `Net::HTTPBadResponse` / `Net::HTTPHeaderSyntaxError`).
 - gzip-encoded backend responses are forwarded verbatim (Content-Encoding and
   Content-Length preserved) instead of being transparently inflated.
 - Skip all `1xx` interim responses (including `103 Early Hints`) on the streaming
@@ -54,6 +66,9 @@ This entry collects the 2026 modernization + security-hardening work (see
 ### Deprecated
 
 - `:ssl_version` — use `:min_version` / `:max_version`.
+- `require "net_http_hacked"` — the monkey-patch is no longer used by the
+  library. The file remains as a functional shim that warns on require, and
+  will be removed in a future release.
 
 ## [0.8.3] - 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project aims to
+follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+This entry collects the 2026 modernization + security-hardening work (see
+`MODERNIZATION_PLAN.md`). It is not yet released.
+
+### Security
+
+- Strip hop-by-hop headers from the **forwarded request** (Connection, TE,
+  Transfer-Encoding, Proxy-Authorization, …, plus any header named by the inbound
+  `Connection` header), closing a Content-Length/Transfer-Encoding request-smuggling
+  surface. Hop-by-hop headers were previously stripped only from the response.
+- Add `backend_allowed?(backend)` — an overridable SSRF guardrail. It defaults to
+  allowing any backend (backward compatible); override it to allowlist expected
+  hosts when the destination is derived from the client `Host` header. A refused
+  backend responds `502`.
+- Add `:max_response_length` to cap the backend response size (bounds memory
+  against a hostile/huge backend). Enforced incrementally while streaming.
+- Add `:ca_file` / `:cert_store` so private-CA backends can be verified under the
+  default `VERIFY_PEER` instead of disabling verification.
+- Add `:open_timeout` / `:write_timeout` to bound connect and per-write stalls
+  (previously only `:read_timeout` was configurable).
+
+### Added
+
+- `:min_version` / `:max_version` TLS options (mapping to `Net::HTTP#min_version=`
+  / `#max_version=`). `:ssl_version` still works but is deprecated (it pins an
+  exact protocol and forbids TLS 1.3).
+- `HttpStreamingResponse#close` so Rack servers release the backend connection on
+  early termination (HEAD, 304, client disconnect) instead of leaking it until GC.
+- Project scaffolding: `SECURITY.md`, `CHANGELOG.md`, `CONTRIBUTING.md`,
+  `CLAUDE.md`/`AGENTS.md`, GitHub Actions CI (Ruby 3.1–3.4 × Rack 2/3), Dependabot.
+
+### Changed
+
+- Backend and construction failures now map to status codes instead of raising a
+  `500`: `400` (malformed request URI), `501` (unknown HTTP method), `502`
+  (broadened backend-error set incl. `ECONNRESET`, `EPIPE`, read/write timeouts,
+  `EOFError`, `OpenSSL::SSL::SSLError`, protocol errors).
+- gzip-encoded backend responses are forwarded verbatim (Content-Encoding and
+  Content-Length preserved) instead of being transparently inflated.
+- Skip all `1xx` interim responses (including `103 Early Hints`) on the streaming
+  path, so a backend's `103` is no longer mistaken for the final response.
+- `rack` dependency constrained to `>= 2.0, < 4`; the library now `require`s rack
+  itself.
+- Test suite is fully offline (local WEBrick server); the previous live-host
+  tests are gated behind `LIVE=1`.
+
+### Deprecated
+
+- `:ssl_version` — use `:min_version` / `:max_version`.
+
+## [0.8.3] - 2025
+
+### Fixed
+
+- Handle non-rewindable request body streams (Rack 3 input streams need not
+  respond to `#rewind`). (#128)
+
+## [0.8.2] - 2025
+
+### Fixed
+
+- Harden `build_header_hash` against a top-level `::Headers` constant defined by
+  the host app being picked up instead of `Rack::Headers`.
+
+## [0.8.1] - 2025
+
+### Added
+
+- `:logger` option, wired to `Net::HTTP#set_debug_output` for wire-level debug
+  output. (#80)
+
+## [0.8.0] - 2025
+
+### Changed
+
+- **BREAKING:** TLS certificate verification now defaults to `VERIFY_PEER`
+  (Ruby's `Net::HTTP` default). Previous versions silently used `VERIFY_NONE` for
+  HTTPS backends. Pass `ssl_verify_none: true` (or `verify_mode:`) to opt out. (#113)
+
+### Fixed
+
+- Return `502` on backend connection errors instead of raising; correct body
+  handling for empty responses and no-entity-body statuses (1xx/204/304). (#58, #122, #123)
+
+---
+
+Older releases (≤ 0.7.8) predate this changelog; see the git history and tags.
+
+[Unreleased]: https://github.com/ncr/rack-proxy/compare/v0.8.3...HEAD
+[0.8.3]: https://github.com/ncr/rack-proxy/compare/v0.8.2...v0.8.3
+[0.8.2]: https://github.com/ncr/rack-proxy/compare/v0.8.1...v0.8.2
+[0.8.1]: https://github.com/ncr/rack-proxy/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/ncr/rack-proxy/compare/v0.7.8...v0.8.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ The living improvement roadmap is [`MODERNIZATION_PLAN.md`](MODERNIZATION_PLAN.m
 
 ```sh
 bundle install
-bundle exec rake test        # full suite, fully OFFLINE, ~0.2s
+bundle exec rake test        # full suite, fully OFFLINE, ~2-3s
 LIVE=1 bundle exec rake test  # additionally runs real-internet smoke tests
 
 # Run the suite against a specific Rack major (CI does both):
@@ -24,7 +24,7 @@ The default suite must never touch the network. CI (`.github/workflows/ci.yml`)
 runs the matrix Ruby 3.1–3.4 × Rack 2/3, a `ruby head` canary, and a gem-build
 smoke test.
 
-## Architecture (three core files, ~360 lines)
+## Architecture (two core files + a deprecated shim, ~500 lines)
 
 - **`lib/rack/proxy.rb`** — `Rack::Proxy`. The entry point: `call` →
   `rewrite_env` → `perform_request` → `rewrite_response`. `perform_request`
@@ -33,25 +33,35 @@ smoke test.
   non-streaming (`streaming: false`). Subclasses override `rewrite_env` /
   `rewrite_response` (and sometimes `perform_request`); see `lib/rack_proxy_examples/`.
 - **`lib/rack/http_streaming_response.rb`** — `HttpStreamingResponse`, the lazy
-  Rack body used by the streaming path. Its `#each` streams the backend response
-  and closes the connection in `ensure`.
-- **`lib/net_http_hacked.rb`** — a monkey-patch of **private** `Net::HTTP`
-  internals that turns block-style streaming into return-style, so the response
-  can become a Rack body. This is the fragile heart of the streaming path.
+  Rack body used by the streaming path. It runs the public block form of
+  `Net::HTTP#request` inside a **Fiber**: the Fiber pauses once the status and
+  headers are in, and `#each` resumes it to pull body chunks; `#each`/`#close`
+  tear the connection down (early termination unwinds the Fiber via
+  `Fiber#raise`).
+- **`lib/net_http_hacked.rb`** — the *former* streaming engine: a monkey-patch
+  of private `Net::HTTP` internals, now a **deprecated shim** kept for one
+  release for external requirers. Nothing in the library loads it anymore; it
+  warns on require. Don't build anything new on it.
 
 ## Invariants — do not regress these (each has a guarding test)
 
-- **TLS verification defaults to `VERIFY_PEER`.** Set in **both** the streaming
-  and non-streaming branches of `perform_request` as
-  `@verify_mode || OpenSSL::SSL::VERIFY_PEER`. If you touch one branch, touch the
-  other — they must match. This regressed to `VERIFY_NONE`-by-default for years.
-  Guards: `test_ssl_default_is_verify_peer`,
-  `test_https_default_rejects_invalid_certificate`.
+- **TLS verification defaults to `VERIFY_PEER`.** The fallback
+  (`@verify_mode || OpenSSL::SSL::VERIFY_PEER`) lives in exactly ONE place —
+  `configure_backend_connection` in `lib/rack/proxy.rb` — and both the streaming
+  and non-streaming paths must keep going through it. Never re-introduce
+  per-branch TLS setup; the duplicated version of this config shipped
+  `VERIFY_NONE`-by-default for years. Guards: `test_ssl_default_is_verify_peer`,
+  `test_https_default_rejects_invalid_certificate(_streaming)`.
 - **Connection failures return `502`, never raise.** Guards:
   `test_connection_refused_returns_502(_streaming)`, `test_unknown_host_returns_502`.
-- **Hop-by-hop headers are stripped from the response.** Guard:
-  `test_response_header_included_Hop_by_hop`. (Request-side stripping is still a
-  TODO — see MODERNIZATION_PLAN P0-2.)
+- **Hop-by-hop headers are stripped from both the response and the forwarded
+  request** (request side also drops anything named by the inbound `Connection`
+  header). Guards: `test_response_header_included_Hop_by_hop`,
+  `test_request_hop_by_hop_headers_are_stripped`.
+- **The streaming session never retries (`max_retries = 0`).** Net::HTTP's
+  default idempotent retry would silently replay the request and restart the
+  body after the headers were already sent to the client. Guard:
+  `test_streaming_session_never_retries`.
 - **No entity body for 1xx/204/304.** Guards: `test_no_entity_body_for_204/304`.
 - **Non-rewindable request bodies must not raise** (Rack 3 input streams need not
   respond to `#rewind`). Guard: `test_non_rewindable_body_is_forwarded_without_raising`.
@@ -60,14 +70,18 @@ smoke test.
 
 ## Traps — things that look wrong but are load-bearing
 
-- **Do not "clean up," modernize, or delete `net_http_hacked.rb` casually.** It
-  depends on private `Net::HTTP` internals; small changes silently break
-  streaming across Ruby versions. The planned replacement is a Fiber-based
-  rewrite (MODERNIZATION_PLAN P1-5) — do that deliberately, with tests, not as a
-  drive-by refactor.
-- **Never add `webmock` or `vcr`.** They monkey-patch `net/http` and break the
-  streaming path. Tests exercise real traffic against a local WEBrick server
-  instead.
+- **The Fiber plumbing in `HttpStreamingResponse` is deliberate — don't
+  "simplify" it.** Three load-bearing choices: (1) `max_retries = 0` (see
+  invariants); (2) early termination unwinds the Fiber with `StreamAborted`, a
+  direct `StandardError` subclass that must never match the network-error
+  classes `Net::HTTP#request` retries on/rescues, or an abort could replay the
+  request; (3) the request's `@decode_content` is forced off so gzip bodies are
+  forwarded verbatim (inflating them desyncs Content-Length/Content-Encoding).
+  A Fiber is also thread-affine: `#close` from a foreign thread skips the unwind
+  and hard-closes the socket — that fallback is intentional.
+- **Never add `webmock` or `vcr` to this repo's tests.** Tests must exercise
+  real Net::HTTP traffic against the local WEBrick server — request-stubbing
+  layers would turn the streaming tests into fiction.
 - **New tests must be offline.** Use `with_webrick_proxy` (in
   `test/rack_proxy_test.rb`) or `ProxyTestServer` (in
   `test/support/proxy_test_server.rb`). Do **not** reintroduce live-host tests;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,13 @@ BUNDLE_GEMFILE=gemfiles/rack_2.gemfile bundle exec rake test
   `test/support/proxy_test_server.rb`). Do not add live-host tests; put anything
   that genuinely needs the internet behind `ENV["LIVE"]` in
   `test/live_smoke_test.rb`.
-- **Do not add `webmock` or `vcr`** — they monkey-patch `net/http` and break the
-  streaming code path.
-- **Do not casually refactor `lib/net_http_hacked.rb`.** It depends on private
-  `Net::HTTP` internals; changes there can silently break streaming. The planned
-  replacement is a deliberate Fiber-based rewrite (see `MODERNIZATION_PLAN.md`).
+- **Do not add `webmock` or `vcr`** — tests must exercise real `Net::HTTP`
+  traffic; request-stubbing layers would make the streaming tests meaningless.
+- **Do not "simplify" the Fiber plumbing in `HttpStreamingResponse`.** The
+  `max_retries = 0`, the `StreamAborted` unwind class, and the forced
+  `decode_content = false` are load-bearing (see the trap list in
+  [`CLAUDE.md`](CLAUDE.md)). `lib/net_http_hacked.rb` is a deprecated shim
+  scheduled for removal — don't build on it.
 - **Keep the test framework as `test-unit`.**
 - New behavior needs a regression test; bug fixes should add a test that fails
   before the fix.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to rack-proxy
+
+Thanks for helping improve rack-proxy. It is a small, security-sensitive library,
+so the bar is safe defaults, no surprises, and no regressions of the security
+behavior documented in [`CLAUDE.md`](CLAUDE.md).
+
+## Getting started
+
+```sh
+bundle install
+bundle exec rake test          # full suite, fully OFFLINE, ~0.2s
+```
+
+The default suite never touches the network. To additionally run the real-internet
+smoke tests:
+
+```sh
+LIVE=1 bundle exec rake test
+```
+
+To run against a specific Rack major (CI runs both):
+
+```sh
+BUNDLE_GEMFILE=gemfiles/rack_3.gemfile bundle exec rake test
+BUNDLE_GEMFILE=gemfiles/rack_2.gemfile bundle exec rake test
+```
+
+## Ground rules
+
+- **Read [`CLAUDE.md`](CLAUDE.md) first.** It lists the security invariants (each
+  mapped to its guarding test) and the traps.
+- **Tests must be offline.** Use `with_webrick_proxy` (in
+  `test/rack_proxy_test.rb`) or `ProxyTestServer` (in
+  `test/support/proxy_test_server.rb`). Do not add live-host tests; put anything
+  that genuinely needs the internet behind `ENV["LIVE"]` in
+  `test/live_smoke_test.rb`.
+- **Do not add `webmock` or `vcr`** — they monkey-patch `net/http` and break the
+  streaming code path.
+- **Do not casually refactor `lib/net_http_hacked.rb`.** It depends on private
+  `Net::HTTP` internals; changes there can silently break streaming. The planned
+  replacement is a deliberate Fiber-based rewrite (see `MODERNIZATION_PLAN.md`).
+- **Keep the test framework as `test-unit`.**
+- New behavior needs a regression test; bug fixes should add a test that fails
+  before the fix.
+
+## Pull requests
+
+1. Fork and branch from `master`.
+2. Make the change with tests; keep `bundle exec rake test` green on Rack 2 and 3.
+3. Add a `CHANGELOG.md` entry under `[Unreleased]`.
+4. Open the PR describing the streaming/non-streaming paths affected and the
+   backend scheme, if relevant.
+
+## Reporting security issues
+
+Please do **not** open a public issue. See [`SECURITY.md`](SECURITY.md).
+
+## Releasing (maintainers)
+
+1. Update `lib/rack/proxy/version.rb` and move the `[Unreleased]` changelog entry
+   under the new version.
+2. Tag `vX.Y.Z` and push; the release workflow publishes the gem.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rack-proxy (0.8.3)
-      rack
+      rack (>= 2.0, < 4)
 
 GEM
   remote: https://rubygems.org/
@@ -18,6 +18,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 Jacek Becela jacek.becela@gmail.com
+Copyright (c) 2010-2026 Jacek Becela and contributors jacek.becela@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MODERNIZATION_PLAN.md
+++ b/MODERNIZATION_PLAN.md
@@ -7,10 +7,35 @@
 >   `:ca_file`/`:cert_store` (P1-6, incl. hermetic VERIFY_PEER-success test),
 >   `:open_timeout`/`:write_timeout` (P2-2), `:min_version`/`:max_version` (P2-8),
 >   rack pin + `require "rack"` (P1-7), `:max_response_length` (P2-3), example load
->   safety (P2-5 partial — physical move + README deferred to Batch 4), and a
->   load-time guard on the monkey-patch (P1-5 interim).
-> - **Still open:** P1-5 the Fiber-based rewrite that retires `net_http_hacked.rb`
->   (high-risk, deserves a dedicated pass); Batch 4 (docs, supply-chain, README, polish).
+>   safety (P2-5 partial), and a load-time guard on the monkey-patch (P1-5 interim).
+> - Batch 4 docs & supply-chain — DONE, branch `modernization/batch-4-docs-supply-chain`:
+>   `SECURITY.md` + README "Security considerations" (P1-8), `CHANGELOG.md` +
+>   gemspec metadata/MFA (P1-9), README accuracy overhaul (P2-1), `CONTRIBUTING.md`,
+>   `frozen_string_literal` pragmas (P2-7 partial), LICENSE year.
+>
+> ## Continuation / handoff (read this if resuming on another machine)
+>
+> Four branches are **stacked**, each its own PR — merge in order:
+> `batch-1-green-loop` → `batch-2-security` → `batch-3-tls-timeouts` → `batch-4-docs-supply-chain`.
+> `master` is untouched. Run tests with `bundle exec rake test` (offline, ~0.2s);
+> CI covers Ruby 3.1–3.4 × Rack 2/3. See [`CLAUDE.md`](CLAUDE.md) for invariants/traps.
+>
+> **Decisions locked in:** (1) the P0-4 SSRF `backend_allowed?` default stays
+> allow-all until a **major** version bump; (2) the P1-5 Fiber rewrite is
+> deferred as its own dedicated, heavily-tested pass (not started).
+>
+> **Still open / next up:**
+> - **P1-5** — Fiber-based rewrite retiring `lib/net_http_hacked.rb` (the one
+>   high-risk item; monkey-patch works and is guarded in the meantime).
+> - **P2-7 remainder** — adopt Standard/RuboCop and add a lint + `bundler-audit`
+>   CI job (frozen-string pragmas already landed; a full `--fix` should be its own commit).
+> - **P2-5 remainder** — physically move `lib/rack_proxy_examples/` → `examples/`
+>   and rework the README to copy-paste snippets (deferred so the documented
+>   `require 'rack_proxy_examples/...'` flow keeps working until then).
+> - **P3 polish** — SimpleCov coverage floor, `.github` issue/PR templates,
+>   opt-in credential/XFF stripping conveniences.
+> - When ready to release, bump `lib/rack/proxy/version.rb`, move the CHANGELOG
+>   `[Unreleased]` section under the new version, tag `vX.Y.Z`.
 
 Baseline already in place (do **not** redo): VERIFY_PEER default (proxy.rb:149/158), 502-on-connect-error mapping (proxy.rb:172), Rack 3 `Headers`/Rack 2 `HeaderHash` branch (proxy.rb:44-50), non-rewindable body guard (proxy.rb:131), `:logger` option. Everything below builds on that.
 

--- a/MODERNIZATION_PLAN.md
+++ b/MODERNIZATION_PLAN.md
@@ -12,21 +12,30 @@
 >   `SECURITY.md` + README "Security considerations" (P1-8), `CHANGELOG.md` +
 >   gemspec metadata/MFA (P1-9), README accuracy overhaul (P2-1), `CONTRIBUTING.md`,
 >   `frozen_string_literal` pragmas (P2-7 partial), LICENSE year.
+> - Batch 5 Fiber streaming rewrite — DONE, branch `modernization/batch-5-fiber-streaming`:
+>   P1-5 landed. `HttpStreamingResponse` now streams via the public block form of
+>   `Net::HTTP#request` run inside a Fiber (yield at headers, resume per chunk,
+>   `Fiber#raise`-unwind on early close); `net_http_hacked.rb` is a deprecated
+>   functional shim (warns on require, removal next release). Load-bearing details:
+>   `max_retries = 0` (no silent request replay mid-stream), `StreamAborted` is a
+>   plain StandardError (must never match net/http's retriable classes), request
+>   `decode_content` forced off (verbatim gzip pass-through). New guards: close
+>   after headers, mid-stream break/abort, HEAD, streaming 204/304, mid-stream
+>   backend death, never-retry, shim deprecation warning.
 >
 > ## Continuation / handoff (read this if resuming on another machine)
 >
-> Four branches are **stacked**, each its own PR — merge in order:
-> `batch-1-green-loop` → `batch-2-security` → `batch-3-tls-timeouts` → `batch-4-docs-supply-chain`.
+> Five branches are **stacked**, each its own PR — merge in order:
+> `batch-1-green-loop` → `batch-2-security` → `batch-3-tls-timeouts` →
+> `batch-4-docs-supply-chain` → `batch-5-fiber-streaming`.
 > `master` is untouched. Run tests with `bundle exec rake test` (offline, ~0.2s);
 > CI covers Ruby 3.1–3.4 × Rack 2/3. See [`CLAUDE.md`](CLAUDE.md) for invariants/traps.
 >
 > **Decisions locked in:** (1) the P0-4 SSRF `backend_allowed?` default stays
-> allow-all until a **major** version bump; (2) the P1-5 Fiber rewrite is
-> deferred as its own dedicated, heavily-tested pass (not started).
+> allow-all until a **major** version bump; (2) `net_http_hacked.rb` stays as a
+> deprecated functional shim for exactly one release, then gets deleted.
 >
 > **Still open / next up:**
-> - **P1-5** — Fiber-based rewrite retiring `lib/net_http_hacked.rb` (the one
->   high-risk item; monkey-patch works and is guarded in the meantime).
 > - **P2-7 remainder** — adopt Standard/RuboCop and add a lint + `bundler-audit`
 >   CI job (frozen-string pragmas already landed; a full `--fix` should be its own commit).
 > - **P2-5 remainder** — physically move `lib/rack_proxy_examples/` → `examples/`
@@ -37,7 +46,7 @@
 > - When ready to release, bump `lib/rack/proxy/version.rb`, move the CHANGELOG
 >   `[Unreleased]` section under the new version, tag `vX.Y.Z`.
 
-Baseline already in place (do **not** redo): VERIFY_PEER default (proxy.rb:149/158), 502-on-connect-error mapping (proxy.rb:172), Rack 3 `Headers`/Rack 2 `HeaderHash` branch (proxy.rb:44-50), non-rewindable body guard (proxy.rb:131), `:logger` option. Everything below builds on that.
+Baseline already in place (do **not** redo): VERIFY_PEER default (now centralized in `configure_backend_connection`), 502-on-backend-error mapping, Rack 3 `Headers`/Rack 2 `HeaderHash` branch, non-rewindable body guard, `:logger` option. Line references in the item bodies below describe the codebase as it was when the plan was written — the progress banner above is the source of truth for what has landed.
 
 Effort key: **S** ≤ ½ day · **M** ~1-2 days · **L** ~several days. `[agent-DX]` = directly serves the goal of a repo that is easy + safe for AI agents to work in.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
+# Rack::Proxy
+
 A request/response rewriting HTTP proxy. A Rack app. Subclass `Rack::Proxy` and provide your `rewrite_env` and `rewrite_response` methods.
+
+## Contents
+
+- [Installation](#installation)
+- [Use Cases](#use-cases)
+- [Options](#options)
+- [Security considerations](#security-considerations)
+- [Examples](#examples)
+- [Upgrading](#upgrading)
+- [A note on header keys](#a-note-on-header-keys-96)
+- [Compatibility notes](#compatibility-notes)
 
 Installation
 ----
@@ -36,20 +49,63 @@ Options
 
 Options can be set when initializing the middleware or overriding a method.
 
+* `:streaming` - stream the backend response as it arrives (default `true`). Set to `false` to buffer the whole response before returning it (also required under `webmock`/`vcr` — see [Compatibility notes](#compatibility-notes)).
+* `:backend` - URI (or URI-parseable string) of the backend host/port/scheme to proxy to. If not set, the destination is derived from the incoming request's `Host` — see [Security considerations](#security-considerations).
+* `:read_timeout` - per-read timeout in seconds (default `60`).
+* `:open_timeout` - connection-open timeout in seconds.
+* `:write_timeout` - per-write timeout in seconds.
+* `:ssl_verify_none` - skip TLS certificate verification. Verification is on by default (`VERIFY_PEER`) — see [Upgrading](#upgrading).
+* `:verify_mode` - explicit `OpenSSL::SSL::VERIFY_*` constant; wins over `ssl_verify_none`.
+* `:ca_file` - path to a PEM CA bundle used to verify the backend certificate (prefer this over disabling verification for private CAs).
+* `:cert_store` - an `OpenSSL::X509::Store` used to verify the backend certificate.
+* `:cert` / `:key` - client certificate and key for mutual TLS to the backend.
+* `:min_version` / `:max_version` - TLS protocol range (e.g. `:TLS1_2`), mapped to `Net::HTTP#min_version=` / `#max_version=`.
+* `:ssl_version` - **deprecated**; pins an exact protocol (forbids TLS 1.3). Use `:min_version` / `:max_version`.
+* `:max_response_length` - cap (in bytes) on the backend response size; a larger response is refused with `502` (streaming aborts once the cap is passed).
+* `:username` / `:password` - HTTP Basic credentials sent to the backend.
+* `:logger` - any object responding to `#<<` (e.g. `$stdout`, a `StringIO`, or a Ruby `Logger`). Wired to `Net::HTTP#set_debug_output` so the HTTP wire-level conversation is written to the sink. Useful for debugging.
 
-* `:streaming` - defaults to `true`, but does not work on all Ruby versions, recommend to set to `false`
-* `:ssl_verify_none` - tell `Net::HTTP` to skip TLS certificate verification (defaults to verifying — see [Upgrading](#upgrading) for the 0.8 change)
-* `:verify_mode` - explicit `OpenSSL::SSL::VERIFY_*` constant; wins over `ssl_verify_none`
-* `:ssl_version` - tell `Net::HTTP` to set a specific `ssl_version`
-* `:backend` - the URI parseable format of host and port of the target proxy backend. If not set it will assume the backend target is the same as the source.
-* `:read_timeout` - set proxy timeout it defaults to 60 seconds
-* `:logger` - any object responding to `#<<` (e.g. `$stdout`, a `StringIO`, or a Ruby `Logger`). Wired through to `Net::HTTP#set_debug_output` so the full HTTP wire-level conversation is written to the sink. Useful for debugging.
+Two request-scoped overrides can also be set in `env` (e.g. from `rewrite_env`):
+
+* `env['rack.backend']` - a URI overriding `:backend` for this request.
+* `env['http.read_timeout']` - override `:read_timeout` for this request.
 
 To pass in options, when you configure your middleware you can pass them in as an optional hash.
 
 ```ruby
 Rails.application.config.middleware.use ExampleServiceProxy, backend: 'http://guides.rubyonrails.org', streaming: false
 ```
+
+Security considerations
+----
+
+rack-proxy forwards attacker-influenced requests to a backend and relays the backend's response. Configure and subclass it with that in mind.
+
+* **SSRF / open proxy.** If you do **not** set `:backend`, the destination host/port/scheme is derived from the incoming request's `Host` / `X-Forwarded-Host` header. A bare `Rack::Proxy.new` will therefore proxy to *any* host a client names — including cloud metadata endpoints (`169.254.169.254`), loopback, and private ranges. Either set a fixed `:backend`, or override `backend_allowed?(backend)` to allowlist expected hosts:
+
+    ```ruby
+    class MyProxy < Rack::Proxy
+      ALLOWED = %w[api.internal.example.com].freeze
+
+      def backend_allowed?(backend)
+        ALLOWED.include?(backend.host)
+      end
+    end
+    ```
+
+    A refused backend is answered with `502`. (Making dynamic, `Host`-derived backends opt-in by default is planned for a future major version.)
+
+* **Credential forwarding.** All incoming `HTTP_*` headers are forwarded, including `Authorization` and `Cookie`. Don't proxy to a different trust domain with credentials attached; strip them in `rewrite_env` (e.g. `env['HTTP_COOKIE'] = ''`). Over an `http://` backend these travel in cleartext.
+
+* **X-Forwarded-For.** rack-proxy appends `REMOTE_ADDR` to any inbound `X-Forwarded-For`. If your clients are not behind a trusted proxy, the inbound value is attacker-controlled; sanitize it in `rewrite_env` when the backend trusts that header.
+
+* **TLS verification** defaults to `VERIFY_PEER`. For private-CA backends use `:ca_file` / `:cert_store` rather than `ssl_verify_none: true`.
+
+* **Resource limits.** Use `:max_response_length` plus `:open_timeout` / `:write_timeout` / `:read_timeout` to bound memory and stalls against a hostile or slow backend.
+
+* **Hop-by-hop headers** (Connection, TE, Transfer-Encoding, Proxy-Authorization, …) are stripped from both the forwarded request and the response.
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 Examples
 ----
@@ -132,7 +188,7 @@ Test with `require 'rack_proxy_examples/example_service_proxy'`
 # 1. rails new test_app
 # 2. cd test_app
 # 3. install Rack-Proxy in `Gemfile`
-#    a. `gem 'rack-proxy', '~> 0.7.7'`
+#    a. `gem 'rack-proxy', '~> 0.8.0'`
 # 4. install gem: `bundle install`
 # 5. create `config/initializers/proxy.rb` adding this line `require 'rack_proxy_examples/example_service_proxy'`
 # 6. run: `SERVICE_URL=http://guides.rubyonrails.org rails server`
@@ -307,7 +363,7 @@ key_raw = File.read('./certs/key.pem')
 cert = OpenSSL::X509::Certificate.new(cert_raw)
 key = OpenSSL::PKey.read(key_raw)
 
-use TLSProxy, cert: cert, key: key, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_PEER, ssl_version: 'TLSv1_2'
+use TLSProxy, cert: cert, key: key, verify_mode: OpenSSL::SSL::VERIFY_PEER, min_version: :TLS1_2
 ```
 
 And rewrite host for example:
@@ -346,14 +402,7 @@ Per the standard Rack/CGI convention, header names received by your proxy are ex
 
 If you need underscore-style headers preserved end-to-end, configure your fronting web server (e.g. `underscores_in_headers on;` in nginx, or `HTTPProtocolOptions` in Apache) — rack-proxy is not the right layer to fix this.
 
-WARNING
+Compatibility notes
 ----
 
-Doesn't work with `fakeweb`/`webmock`. Both libraries monkey-patch net/http code.
-
-Todos
-----
-
-* Make the docs up to date with the current use case for this code: everything except streaming which involved a rather ugly monkey patch and only worked in 1.8, but does not work now.
-* Improve and validate requirements for Host and Path rewrite rules
-* Ability to inject logger and set log level
+The streaming response path (the default) reads directly from `Net::HTTP`, so it does not work under `webmock`, `vcr`, or `fakeweb`, which monkey-patch `net/http`. If you use those libraries in your tests, set `streaming: false`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Options
 
 Options can be set when initializing the middleware or overriding a method.
 
-* `:streaming` - stream the backend response as it arrives (default `true`). Set to `false` to buffer the whole response before returning it (also required under `webmock`/`vcr` — see [Compatibility notes](#compatibility-notes)).
+* `:streaming` - stream the backend response as it arrives (default `true`). Set to `false` to buffer the whole response before returning it (also recommended under `webmock`/`vcr` — see [Compatibility notes](#compatibility-notes)).
 * `:backend` - URI (or URI-parseable string) of the backend host/port/scheme to proxy to. If not set, the destination is derived from the incoming request's `Host` — see [Security considerations](#security-considerations).
 * `:read_timeout` - per-read timeout in seconds (default `60`).
 * `:open_timeout` - connection-open timeout in seconds.
@@ -405,4 +405,4 @@ If you need underscore-style headers preserved end-to-end, configure your fronti
 Compatibility notes
 ----
 
-The streaming response path (the default) reads directly from `Net::HTTP`, so it does not work under `webmock`, `vcr`, or `fakeweb`, which monkey-patch `net/http`. If you use those libraries in your tests, set `streaming: false`.
+The streaming response path (the default) streams straight off the backend socket via `Net::HTTP`. Historically it relied on private `net/http` internals and did not work at all under `webmock`, `vcr`, or `fakeweb`; it now uses only the public `Net::HTTP#request` API, but those libraries still replace the real network layer, so behavior under them is not guaranteed. In tests that stub HTTP, prefer `streaming: false`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+`rack-proxy` is a request/response-rewriting HTTP proxy. Because it forwards
+attacker-influenced requests to a backend and relays the backend's response, how
+you configure and subclass it has direct security consequences. Please read the
+threat model below alongside the "Security considerations" section of the README.
+
+## Supported versions
+
+Security fixes are released for the latest `0.x` minor series. Older versions are
+not maintained — please upgrade before reporting.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.8.x   | ✅        |
+| < 0.8   | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately through GitHub's **Report a vulnerability** button under the
+repository's *Security* tab (Private Vulnerability Reporting). If that is
+unavailable to you, email the maintainer at **jacek.becela@gmail.com** with
+`[rack-proxy security]` in the subject.
+
+Please include:
+
+- the rack-proxy, Rack, and Ruby versions,
+- whether you run in streaming (`streaming: true`, the default) or non-streaming mode,
+- a minimal `config.ru` / subclass that reproduces the issue,
+- the impact you observed.
+
+We aim to acknowledge a report within **5 business days** and to agree on a
+disclosure timeline from there. We are grateful for responsible disclosure and
+will credit reporters who want it.
+
+## Scope
+
+In scope: defects in the library itself — for example, credentials or hop-by-hop
+headers being forwarded when they should not be, request/response smuggling,
+verification defaults that are weaker than documented, or a crash/`500` where a
+`4xx`/`5xx` mapping is expected.
+
+Out of scope: insecure **configuration or subclassing** of the library. In
+particular, deriving the backend from a client-controlled `Host` header without
+an allowlist is an SSRF/open-proxy risk that is the deployer's responsibility to
+prevent — see `backend_allowed?` and the README. If the documentation is what led
+you astray, that is in scope: tell us and we will fix the docs.

--- a/lib/net_http_hacked.rb
+++ b/lib/net_http_hacked.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # We are hacking net/http to change semantics of streaming handling
 # from "block" semantics to regular "return" semantics.
 # We need it to construct a streamable rack triplet:

--- a/lib/net_http_hacked.rb
+++ b/lib/net_http_hacked.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
-# We are hacking net/http to change semantics of streaming handling
-# from "block" semantics to regular "return" semantics.
-# We need it to construct a streamable rack triplet:
+# DEPRECATED SHIM — scheduled for removal.
 #
-# [status, headers, streamable_body]
+# rack-proxy no longer uses this monkey-patch: Rack::HttpStreamingResponse now
+# streams through the public block form of Net::HTTP#request, run inside a
+# Fiber (see lib/rack/http_streaming_response.rb). This file is kept for one
+# release only, in case external code requires it directly and calls
+# #begin_request_hacked / #end_request_hacked. It reaches into private
+# net/http internals and can break on any Ruby upgrade — migrate off it.
 #
-# See http://github.com/zerowidth/rack-streaming-proxy
-# for alternative that uses additional process.
-#
-# BTW I don't like monkey patching either
-# but this is not real monkey patching.
-# I just added some methods and named them very uniquely
-# to avoid eventual conflicts. You're safe. Trust me.
-#
-# Also, in Ruby 1.9.2 you could use Fibers to avoid hacking net/http.
+# Historical context: the patch turned net/http's block-style streaming into
+# return-style so the response could become a Rack body. See
+# http://github.com/zerowidth/rack-streaming-proxy for an alternative that
+# used an additional process.
 
 require 'net/https'
+
+warn "[DEPRECATION] rack-proxy's net_http_hacked is deprecated and no longer used by " \
+     "Rack::Proxy (streaming now uses the public Net::HTTP API). It will be removed in " \
+     "a future release; stop requiring 'net_http_hacked'.", uplevel: 0
 
 class Net::HTTP
   # Original #request with block semantics.
@@ -94,15 +96,16 @@ class Net::HTTPResponse
   end
 end
 
-# Fail loudly (a warning, so non-streaming users are unaffected) if a future
-# net/http drops the private internals this patch reaches into, instead of
-# breaking mysteriously at request time. The planned Fiber-based rewrite (see
-# MODERNIZATION_PLAN.md P1-5) removes this dependency entirely.
+# Fail loudly (a warning) if this Ruby's net/http has dropped the private
+# internals the shim reaches into, instead of breaking mysteriously at call
+# time. Rack::Proxy itself is unaffected either way — its streaming uses the
+# public Net::HTTP API (lib/rack/http_streaming_response.rb).
 _rack_proxy_missing_net_http = %i[begin_transport end_transport edit_path].reject do |m|
   Net::HTTP.private_method_defined?(m) || Net::HTTP.method_defined?(m)
 end
 _rack_proxy_missing_net_http << :read_new unless Net::HTTPResponse.respond_to?(:read_new, true)
 unless _rack_proxy_missing_net_http.empty?
   warn "net_http_hacked: Net::HTTP internals #{_rack_proxy_missing_net_http.join(', ')} are " \
-       "missing on Ruby #{RUBY_VERSION}; Rack::Proxy streaming may be broken. Use streaming: false."
+       "missing on Ruby #{RUBY_VERSION}; this deprecated shim is broken here. Migrate to " \
+       "Rack::Proxy's built-in streaming, which does not use these internals."
 end

--- a/lib/rack-proxy.rb
+++ b/lib/rack-proxy.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "rack/proxy"

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "net_http_hacked"
 require "stringio"
 

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -1,14 +1,37 @@
 # frozen_string_literal: true
 
-require "net_http_hacked"
+require "net/https"
 require "stringio"
 
 module Rack
-  # Wraps the hacked net/http in a Rack way.
+  # A lazy Rack body that streams a backend Net::HTTP response without
+  # buffering it.
+  #
+  # The request runs inside a Fiber, using only the public block form of
+  # Net::HTTP#request: the Fiber pauses (`Fiber.yield res`) the moment the
+  # status and headers are available, and #each resumes it to pull body chunks
+  # as the server consumes them. This replaces the historical monkey-patch of
+  # private net/http internals (`net_http_hacked.rb`, now a deprecated shim)
+  # and inherits upstream's handling of 1xx interim responses, keep-alive
+  # negotiation, and transport errors.
+  #
+  # A Fiber can only be resumed from the thread that created it. The request
+  # Fiber is created lazily on first use (#code/#headers/#each), so the normal
+  # Rack flow — one thread calls the app and then iterates the body — is fine.
+  # If #close is called from a different thread (some servers do this on client
+  # abort), the Fiber unwind is skipped and the connection is hard-closed
+  # instead, which releases the socket either way.
   class HttpStreamingResponse
     # Raised while streaming when the backend body exceeds max_response_length.
     # The status/headers are already sent, so the transfer is aborted mid-stream.
     class ResponseTooLarge < StandardError; end
+
+    # Raised INTO the request Fiber to unwind it on early termination (client
+    # abort, HEAD, 204/304, oversize response). Deliberately a direct
+    # StandardError subclass — it must never match the network-error classes
+    # Net::HTTP#request retries on, or aborting a stream could replay the
+    # request against the backend.
+    class StreamAborted < StandardError; end
 
     STATUSES_WITH_NO_ENTITY_BODY = {
       204 => true,
@@ -26,6 +49,15 @@ module Rack
     # direct users of this class).
     def initialize(request, host, port = nil, &configure)
       @request, @host, @port, @configure = request, host, port, configure
+
+      # Forward the backend body verbatim. Without this, Net::HTTP inflates
+      # gzip/deflate bodies for requests that opted in (the default for e.g.
+      # Net::HTTP::Get), leaving the already-forwarded Content-Length and
+      # Content-Encoding describing bytes the client never receives. The old
+      # patched read path never decoded; keep that contract.
+      if request.instance_variable_defined?(:@decode_content)
+        request.instance_variable_set(:@decode_content, false)
+      end
     end
 
     def body
@@ -48,8 +80,14 @@ module Rack
     def each(&block)
       return if connection_closed
 
+      response # make sure the request has started and the headers are in
+
       bytes = 0
-      response.read_body do |chunk|
+      while @fiber.alive?
+        chunk = @fiber.resume
+        # The last resume returns the Fiber's terminal value, not a body chunk.
+        next unless chunk.is_a?(String)
+
         if max_response_length
           bytes += chunk.bytesize
           if bytes > max_response_length
@@ -81,9 +119,28 @@ module Rack
 
     protected
 
-    # Net::HTTPResponse
+    # Net::HTTPResponse. Fetching it lazily dials the backend, sends the request
+    # and reads the response head; the body stays unread on the socket until
+    # #each resumes the Fiber.
     def response
-      @response ||= session.begin_request_hacked(request)
+      return @response if @response
+
+      # Starting a request on a closed body would dial a connection that
+      # nothing can ever release (close_connection has already latched). Check
+      # AFTER the memo: #headers is legitimately read after #code auto-closed a
+      # 204/304, which must keep working.
+      raise IOError, "rack-proxy: backend response was closed before it was read" if connection_closed
+
+      @response = begin
+        @fiber = Fiber.new do
+          session.request(request) do |res|
+            Fiber.yield res
+            res.read_body { |chunk| Fiber.yield chunk }
+          end
+          :done
+        end
+        @fiber.resume
+      end
     end
 
     # Net::HTTP
@@ -100,6 +157,11 @@ module Rack
           http.key = key if key
           http.set_debug_output(logger) if logger
         end
+        # Net::HTTP retries idempotent requests once on transport errors — but a
+        # retry after the response was yielded would silently replay the request
+        # and restart the body mid-stream. The old patched path never retried;
+        # streaming must not either. (Set after the configure block on purpose.)
+        http.max_retries = 0
         http.start
       end
     end
@@ -110,22 +172,32 @@ module Rack
 
     attr_accessor :connection_closed
 
-    # Idempotent, best-effort teardown. Uses @session directly (never the lazy
-    # #session accessor) so closing a response whose body was never read does not
-    # open a connection just to tear it down. Swallows teardown errors: a
-    # half-read or already-reset backend must not crash the app or mask the
-    # original error.
+    # Idempotent, best-effort teardown. Uses @session/@fiber directly (never the
+    # lazy accessors) so closing a response that was never read does not dial
+    # the backend just to tear it down. A still-suspended request Fiber is
+    # unwound first (running net/http's own ensure blocks), then the connection
+    # is closed for real. Swallows teardown errors: a half-read or already-reset
+    # backend must not crash the app or mask the original error.
     def close_connection
-      return if connection_closed || @session.nil?
+      return if connection_closed
 
       self.connection_closed = true
-      begin
-        @session.end_request_hacked
-      ensure
-        @session.finish if @session.started?
+
+      if @fiber&.alive?
+        begin
+          @fiber.raise(StreamAborted, "backend stream closed before the response was fully read")
+        rescue StandardError
+          # Expected: StreamAborted itself (or whatever the unwind trips over)
+          # propagates back out of Fiber#raise; FiberError if another thread
+          # owns the Fiber. Either way we fall through to closing the socket.
+        end
       end
-    rescue StandardError
-      # best-effort: the connection may already be gone
+
+      begin
+        @session.finish if @session&.started?
+      rescue StandardError
+        # best-effort: the connection may already be gone
+      end
     end
   end
 end

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rack"
-require "net_http_hacked"
+require "net/https"
 require "rack/http_streaming_response"
 require "rack/proxy/version"
 
@@ -31,7 +31,11 @@ module Rack
       Net::ReadTimeout, Net::WriteTimeout,
       IOError,                      # includes EOFError
       OpenSSL::SSL::SSLError,
-      Net::ProtocolError            # includes Net::HTTPBadResponse
+      Net::ProtocolError,
+      # A malformed status line / header block raises these; they subclass
+      # StandardError directly, NOT Net::ProtocolError, so list them explicitly
+      # or a hostile backend crashes the proxy with a raw 500 instead of a 502.
+      Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError
     ].freeze
 
     class << self

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rack"
 require "net_http_hacked"
 require "rack/http_streaming_response"

--- a/lib/rack_proxy_examples/example_service_proxy.rb
+++ b/lib/rack_proxy_examples/example_service_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # This is an example of how to use Rack-Proxy in a Rails application.
 #

--- a/lib/rack_proxy_examples/forward_host.rb
+++ b/lib/rack_proxy_examples/forward_host.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ForwardHost < Rack::Proxy
 
   def rewrite_env(env)

--- a/lib/rack_proxy_examples/rack_php_proxy.rb
+++ b/lib/rack_proxy_examples/rack_php_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Open http://localhost:3000/test.php to trigger proxy
 ###

--- a/lib/rack_proxy_examples/trusting_proxy.rb
+++ b/lib/rack_proxy_examples/trusting_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TrustingProxy < Rack::Proxy
 
   def rewrite_env(env)

--- a/rack-proxy.gemspec
+++ b/rack-proxy.gemspec
@@ -14,7 +14,14 @@ Gem::Specification.new do |s|
   s.description = %q{A Rack app that provides request/response rewriting proxy capabilities with streaming.}
   s.required_ruby_version = ">= 3.0"
 
-  s.files = Dir["lib/**/*.rb"] + %w[README.md LICENSE rack-proxy.gemspec]
+  s.metadata = {
+    "source_code_uri"       => "https://github.com/ncr/rack-proxy",
+    "changelog_uri"         => "https://github.com/ncr/rack-proxy/blob/master/CHANGELOG.md",
+    "bug_tracker_uri"       => "https://github.com/ncr/rack-proxy/issues",
+    "rubygems_mfa_required" => "true"
+  }
+
+  s.files = Dir["lib/**/*.rb"] + %w[README.md LICENSE CHANGELOG.md SECURITY.md rack-proxy.gemspec]
   s.require_paths = ["lib"]
 
   s.add_dependency("rack", ">= 2.0", "< 4")

--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -77,4 +77,202 @@ class HttpStreamingResponseTest < Test::Unit::TestCase
     assert_nothing_raised { @response.close }
   end
 
+  # P1-5: closing after only the head was read (the HEAD/204/304 shape) must
+  # unwind the suspended request Fiber and release the connection, and the body
+  # must yield nothing afterwards.
+  def test_close_after_reading_headers_releases_connection
+    assert_equal 200, @response.status
+    assert_nothing_raised { @response.close }
+
+    session = @response.instance_variable_get(:@session)
+    assert_not_nil session
+    assert !session.started?, "connection must be finished after close"
+
+    chunks = []
+    @response.body.each { |chunk| chunks << chunk }
+    assert_empty chunks, "a closed response must not stream a body"
+  end
+
+  # P1-5: a client abort mid-stream (modelled by `break` out of #each) must
+  # close the backend connection instead of leaking the half-read socket.
+  def test_early_break_mid_stream_closes_connection
+    yielded = 0
+    @response.body.each do |_chunk|
+      yielded += 1
+      break
+    end
+
+    assert_equal 1, yielded
+    session = @response.instance_variable_get(:@session)
+    assert_not_nil session
+    assert !session.started?, "breaking out of #each must close the backend connection"
+    assert_nothing_raised { @response.close }
+  end
+
+  # Use-after-close must fail loudly, not dial a backend connection that the
+  # already-latched close_connection could never release.
+  def test_code_after_close_raises_without_dialing
+    req = Net::HTTP::Get.new("/")
+    response = Rack::HttpStreamingResponse.new(req, "127.0.0.1", @server.config[:Port])
+    response.use_ssl = false
+
+    response.close
+    assert_raise(IOError) { response.status }
+    assert_nil response.instance_variable_get(:@session),
+      "a closed response must never dial the backend"
+  end
+
+  # A 204 (also 205/304) must release the backend connection as soon as #code is
+  # read — no #close/#each needed — while #headers stays readable afterwards.
+  def test_204_releases_connection_at_code
+    req = Net::HTTP::Get.new("/no-content")
+    response = Rack::HttpStreamingResponse.new(req, "127.0.0.1", @server.config[:Port])
+    response.use_ssl = false
+
+    assert_equal 204, response.status
+    session = response.instance_variable_get(:@session)
+    assert_not_nil session
+    assert !session.started?, "204 must close the backend connection at #code"
+    assert response.headers.size.positive?, "headers must remain readable after the auto-close"
+  end
+
+  # P1-5: gzip bodies must pass through verbatim on the direct-use path too (no
+  # configure block). Without the forced decode_content=false, Net::HTTP would
+  # inflate the body and desync it from the forwarded Content-Length/-Encoding.
+  def test_gzip_body_passes_through_verbatim_without_configure_block
+    req = Net::HTTP::Get.new("/gzip")
+    response = Rack::HttpStreamingResponse.new(req, "127.0.0.1", @server.config[:Port])
+    response.use_ssl = false
+
+    assert_equal 200, response.status
+    body = +""
+    response.body.each { |chunk| body << chunk }
+    assert_equal "\x1f\x8b".b, body.b[0, 2], "body must still be gzip-compressed on the wire"
+    inflated = Zlib::GzipReader.new(StringIO.new(body.b)).read
+    assert_equal ProxyTestServer::GZIP_PLAINTEXT.b, inflated.b
+  end
+
+  # The no-retry guarantee must hold on the configure-block path too, even if
+  # the block itself tries to enable retries (ordering: forced after configure).
+  def test_configure_block_cannot_reenable_retries
+    req = Net::HTTP::Get.new("/")
+    response = Rack::HttpStreamingResponse.new(req, "127.0.0.1", @server.config[:Port]) do |http|
+      http.max_retries = 2
+    end
+
+    assert_equal 200, response.status
+    assert_equal 0, response.instance_variable_get(:@session).max_retries,
+      "max_retries must be forced to 0 after the configure block runs"
+  end
+
+  # P1-5: a Fiber is thread-affine; #close from a foreign thread must fall back
+  # to hard-closing the connection (no FiberError escaping, no socket leak).
+  def test_close_from_another_thread_releases_connection
+    assert_equal 200, @response.status
+
+    Thread.new { @response.close }.join
+
+    session = @response.instance_variable_get(:@session)
+    assert_not_nil session
+    assert !session.started?, "cross-thread close must still release the connection"
+
+    chunks = []
+    @response.body.each { |chunk| chunks << chunk }
+    assert_empty chunks, "a closed response must not stream a body"
+  end
+
+  # P1-5: an HTTP/1.0-style close-delimited body (no Content-Length, no
+  # Transfer-Encoding; EOF ends the body) must stream fully without raising.
+  def test_http10_eof_delimited_body_streams_fully
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    thread = Thread.new do
+      client = server.accept
+      client.gets("\r\n\r\n") # consume request headers
+      client.write("HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\n\r\n")
+      client.write("eof-delimited body")
+      client.close
+    rescue IOError, Errno::EPIPE, Errno::ECONNRESET
+      # client went away; nothing to do
+    ensure
+      server.close
+    end
+
+    req = Net::HTTP::Get.new("/")
+    response = Rack::HttpStreamingResponse.new(req, "127.0.0.1", port)
+    response.use_ssl = false
+
+    assert_equal 200, response.status
+    body = +""
+    response.body.each { |chunk| body << chunk }
+    assert_equal "eof-delimited body", body
+
+    session = response.instance_variable_get(:@session)
+    assert !session.started?, "connection must be finished after an EOF-delimited body"
+  ensure
+    thread&.join(2)
+  end
+
+  # P1-5: a HEAD request has no body to stream; the response must still expose
+  # status/headers and tear down cleanly.
+  def test_head_request_yields_no_body
+    req = Net::HTTP::Head.new("/")
+    response = Rack::HttpStreamingResponse.new(req, "127.0.0.1", @server.config[:Port])
+    response.use_ssl = false
+
+    assert_equal 200, response.status
+    chunks = []
+    response.body.each { |chunk| chunks << chunk }
+    assert_empty chunks
+
+    session = response.instance_variable_get(:@session)
+    assert !session.started?, "connection must be finished after a body-less stream"
+  end
+
+  # P1-5: Net::HTTP retries idempotent requests on transport errors by default.
+  # A retry after the response head was yielded would silently replay the
+  # request and restart the body mid-stream, so streaming must never retry.
+  def test_streaming_session_never_retries
+    @response.status
+    session = @response.instance_variable_get(:@session)
+    assert_equal 0, session.max_retries,
+      "a mid-stream retry would replay the request and restart the body"
+  end
+
+  # P1-5: when the backend dies mid-body (headers already forwarded), #each must
+  # log, re-raise so the server aborts the transfer, and still close the
+  # connection — a truncated response, never a false "complete".
+  def test_midstream_backend_failure_raises_logs_and_closes
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    thread = Thread.new do
+      client = server.accept
+      client.gets("\r\n\r\n") # consume request headers
+      client.write("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n")
+      client.write("5\r\nhello\r\n")
+      client.close # die before the terminating chunk
+    rescue IOError, Errno::EPIPE, Errno::ECONNRESET
+      # client went away; nothing to do
+    ensure
+      server.close
+    end
+
+    req = Net::HTTP::Get.new("/")
+    response = Rack::HttpStreamingResponse.new(req, "127.0.0.1", port)
+    response.use_ssl = false
+    sink = StringIO.new
+    response.logger = sink
+
+    assert_equal 200, response.status
+    chunks = []
+    assert_raise(EOFError) { response.body.each { |chunk| chunks << chunk } }
+    assert_equal ["hello"], chunks, "chunks before the failure must be delivered"
+    assert_match(/streaming backend read failed/, sink.string)
+
+    session = response.instance_variable_get(:@session)
+    assert !session.started?, "connection must be torn down after a mid-stream failure"
+  ensure
+    thread&.join(2)
+  end
+
 end

--- a/test/net_http_hacked_test.rb
+++ b/test/net_http_hacked_test.rb
@@ -1,5 +1,22 @@
 require "test_helper"
-require "net_http_hacked"
+require "stringio"
+
+# net_http_hacked is a DEPRECATED SHIM (see lib/net_http_hacked.rb): Rack::Proxy
+# no longer uses it, but it is kept working for one release for external code
+# that requires it directly. This file guards both halves of that contract —
+# requiring it warns, and the hacked methods still function until removal.
+#
+# The shim warns at require time, so capture stderr around the require both to
+# assert the deprecation is emitted and to keep the suite output clean.
+captured = StringIO.new
+original_stderr = $stderr
+begin
+  $stderr = captured
+  NET_HTTP_HACKED_FRESHLY_REQUIRED = require "net_http_hacked"
+ensure
+  $stderr = original_stderr
+end
+NET_HTTP_HACKED_REQUIRE_WARNING = captured.string
 
 class NetHttpHackedTest < Test::Unit::TestCase
 
@@ -9,6 +26,26 @@ class NetHttpHackedTest < Test::Unit::TestCase
 
   def teardown
     @server&.shutdown
+  end
+
+  # P1-5: requiring the shim must say loudly that it is deprecated.
+  def test_require_emits_deprecation_warning
+    omit "net_http_hacked was already loaded by another file" unless NET_HTTP_HACKED_FRESHLY_REQUIRED
+    assert_match(/DEPRECATION.*net_http_hacked/m, NET_HTTP_HACKED_REQUIRE_WARNING)
+  end
+
+  # P1-5: the library itself must NOT load the shim — if a stray require creeps
+  # back into lib/, this fails hard (in-process tests can't see it because this
+  # very file loads the shim). Runs in a subprocess for isolation.
+  def test_library_does_not_load_the_shim
+    lib = File.expand_path("../lib", __dir__)
+    out = IO.popen(
+      [RbConfig.ruby, "-I", lib, "-e",
+       'require "rack/proxy"; print Net::HTTP.method_defined?(:begin_request_hacked) ? "LOADED" : "CLEAN"'],
+      err: [:child, :out], &:read
+    )
+    assert_match(/CLEAN\z/, out, "requiring rack/proxy must not load the deprecated net_http_hacked shim")
+    assert_not_match(/DEPRECATION/, out, "requiring rack/proxy must not emit the shim deprecation warning")
   end
 
   def test_net_http_hacked

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -43,9 +43,9 @@ class RackProxyTest < Test::Unit::TestCase
 
   # The offline HTTPS tests proxy over TLS to a self-signed local server with
   # verification disabled, exercising the streaming/non-streaming TLS transport
-  # and the :ssl_version plumbing. The VERIFY_PEER *success* path (a trusted
-  # cert accepted by default) is covered by test/live_smoke_test.rb until the
-  # planned :ca_file option lands, at which point it becomes hermetic too.
+  # and the :ssl_version plumbing. The VERIFY_PEER *success* path is covered
+  # hermetically by test_https_ca_file_accepts_trusted_cert_* below (via
+  # :ca_file); test/live_smoke_test.rb only adds system-trust-store coverage.
   def test_https_streaming
     with_webrick_proxy(ssl: true, ssl_verify_none: true) do |port, proxy|
       proxy.host = "127.0.0.1:#{port}"
@@ -245,6 +245,65 @@ class RackProxyTest < Test::Unit::TestCase
       get '/not-modified'
       assert_equal 304, last_response.status
       assert_equal '', last_response.body
+    end
+  end
+
+  # Same guards on the default (streaming) path: the streaming body must close
+  # the backend connection for these statuses without emitting an entity body
+  # (P1-5 exercises this through the Fiber-based streamer).
+  def test_no_entity_body_for_204_streaming
+    with_webrick_proxy(streaming: true) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get '/no-content'
+      assert_equal 204, last_response.status
+      assert_equal '', last_response.body
+    end
+  end
+
+  def test_no_entity_body_for_304_streaming
+    with_webrick_proxy(streaming: true) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      get '/not-modified'
+      assert_equal 304, last_response.status
+      assert_equal '', last_response.body
+    end
+  end
+
+  def test_head_request_streaming
+    with_webrick_proxy(streaming: true) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      head '/'
+      assert last_response.ok?
+      assert_equal '', last_response.body, 'HEAD must not stream an entity body'
+    end
+  end
+
+  # A request body must round-trip through the default (streaming) path too —
+  # the non-streaming POST coverage alone would let a fiber-path body bug slip.
+  def test_post_body_is_forwarded_streaming
+    with_webrick_proxy(streaming: true) do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      post '/echo-body', 'hello=streaming-world'
+      assert last_response.ok?
+      assert_equal 'hello=streaming-world', last_response.body
+    end
+  end
+
+  # A backend replying with a malformed status line must become a 502, not a
+  # raised Net::HTTPBadResponse (which subclasses StandardError directly, NOT
+  # Net::ProtocolError — easy to get wrong in BACKEND_ERRORS).
+  def test_malformed_backend_response_returns_502
+    [true, false].each do |streaming|
+      with_malformed_backend do |port|
+        proxy = HostProxy.new(streaming: streaming)
+        @app = proxy
+        proxy.host = "127.0.0.1:#{port}"
+        get "/"
+        assert_equal 502, last_response.status,
+          "malformed backend response must 502 (streaming: #{streaming})"
+      ensure
+        @app = nil
+      end
     end
   end
 
@@ -559,6 +618,26 @@ class RackProxyTest < Test::Unit::TestCase
           'Content-Length must match the (compressed) bytes actually forwarded'
       end
     end
+  end
+
+  # A raw TCP backend that replies with a malformed status line (a hostile or
+  # broken backend), to prove the parse failure maps to 502 instead of raising.
+  def with_malformed_backend
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    thread = Thread.new do
+      client = server.accept
+      client.gets("\r\n\r\n") # consume request headers
+      client.write("garbage nonsense\r\n\r\n")
+      client.close
+    rescue IOError, Errno::EPIPE, Errno::ECONNRESET
+      # client went away; nothing to do
+    ensure
+      server.close
+    end
+    yield port
+  ensure
+    thread&.join(2)
   end
 
   # A raw TCP backend that emits a 103 Early Hints interim response followed by a


### PR DESCRIPTION
**Stacked PR 5/7** — base: `modernization/batch-4-docs-supply-chain`. Merge the stack in order (1 → 7).

The P1-5 headline: `HttpStreamingResponse` now streams via the **public** block form of `Net::HTTP#request` run inside a Fiber (yield at headers, resume per chunk, `Fiber#raise`-unwind on early close). `net_http_hacked.rb` becomes a deprecated functional shim (warns on require; deleted in PR 7).

Load-bearing details:
- `max_retries = 0` — no silent request replay mid-stream
- `StreamAborted` is a plain StandardError — must never match net/http's retriable classes
- request `decode_content` forced off — verbatim gzip pass-through

New guards: close-after-headers, mid-stream break/abort, HEAD, streaming 204/304, mid-stream backend death, never-retry, shim deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
