### PR TITLE
Release 1.0.2: bump dev dependency json to 2.21.2 (GHSA-9hj4-r449-hfvc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Nothing yet.
 
+## [1.0.2] - 2026-09-01
+
+Housekeeping — no library behavior changes. **No action is needed by users:**
+the shipped gem does not depend on `json` and was never affected by the
+advisory below.
+
+### Security
+
+- Development dependency `json` bumped 2.21.1 → 2.21.2 to clear
+  CVE-2026-71847 / GHSA-9hj4-r449-hfvc (`JSON::ResumableParser#partial_value`
+  dereferences a freed input buffer on truncated duplicate-key streams).
+  `json` reaches this repo only transitively (`standard` → `rubocop` → `json`)
+  and lives solely in the development `Gemfile.lock`; the bump keeps the CI
+  `bundler-audit` gate green.
+
+### Changed
+
+- Release workflow: the laggy rubygems full-index await was replaced with a
+  versions-API check, so a successful publish no longer fails the run. (#142)
+
 ## [1.0.1] - 2026-07-23
 
 Docs and housekeeping — no library behavior changes.
@@ -175,7 +195,8 @@ or a compatible fix. See the README's "Upgrading" section for migration steps.
 
 Older releases (≤ 0.7.8) predate this changelog; see the git history and tags.
 
-[Unreleased]: https://github.com/ncr/rack-proxy/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/ncr/rack-proxy/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/ncr/rack-proxy/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/ncr/rack-proxy/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/ncr/rack-proxy/compare/v0.8.3...v1.0.0
 [0.8.3]: https://github.com/ncr/rack-proxy/compare/v0.8.2...v0.8.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-proxy (1.0.1)
+    rack-proxy (1.0.2)
       rack (>= 2.0, < 4)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     parallel (2.1.0)

--- a/lib/rack/proxy/version.rb
+++ b/lib/rack/proxy/version.rb
@@ -2,6 +2,6 @@
 
 module Rack
   class Proxy
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end


### PR DESCRIPTION
## Summary

- Bumps the development-only transitive dependency `json` 2.21.1 → 2.21.2 to clear Dependabot alert #35 (CVE-2026-71847 / GHSA-9hj4-r449-hfvc, use-after-free in `JSON::ResumableParser#partial_value`). `json` reaches this repo only via `standard` → `rubocop`; it is not a runtime dependency and is not part of the shipped gem. The bump un-blocks the CI `bundler-audit` gate, which currently fails on `master`.
- Bumps the gem to 1.0.2 and moves the CHANGELOG `[Unreleased]` section under it (also records the #142 release-workflow fix). No library code changes; the CHANGELOG states explicitly that users need no action.

## Test plan

- [x] `bundle exec rake test` — 84 tests, 0 failures (default Gemfile, Rack 2 and Rack 3 gemfiles)
- [x] `bundle exec standardrb` clean
- [x] `bundle exec bundler-audit check --update` — no vulnerabilities
- [x] `gem build rack-proxy.gemspec` builds 1.0.2
- [ ] After merge: tag `v1.0.2` and let `release.yml` publish via Trusted Publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCA78Yh2qnwbNMBvkDQRjk