### PR TITLE
Release 2.0.0: harden HTTP framing and response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Nothing yet.
 
+## [2.0.0] - 2026-09-05
+
+### Breaking changes
+
+- Non-streaming requests no longer automatically retry transport failures.
+  This prevents replay with consumed request input; applications that require
+  retries must implement them with a fresh body and an explicit retry policy.
+- Rack 3 response hooks receive arrays for repeated header values, including
+  `Set-Cookie`, and non-streaming statuses are integers. Update hooks that
+  assumed newline-separated headers or string statuses. Rack 2 retains its
+  newline-separated header representation.
+- Invalid or ambiguous HTTP framing is now rejected, incomplete responses fail,
+  and uploads without a known length use fresh chunked framing. Backends must
+  accept properly framed HTTP/1.1 requests and send valid, complete responses.
+
+### Security
+
+- Reframe decoded request bodies without a `CONTENT_LENGTH` using chunked
+  encoding instead of sending body bytes after `Content-Length: 0`. Bound
+  known-length input streams so excess bytes cannot become another backend
+  request; malformed lengths and prematurely ended uploads return `400`.
+- Reject ambiguous backend framing (`Transfer-Encoding` with `Content-Length`,
+  conflicting or invalid lengths, and unsupported transfer codings) with `502`.
+- Strip response headers named by the backend's `Connection` fields as well as
+  the standard hop-by-hop headers.
+- Enforce `max_response_length` before buffering each chunk in non-streaming
+  mode, including rejecting declared oversized responses before reading them.
+- Detect premature EOF in fixed-length responses: return `502` before sending
+  headers, or raise while streaming so the server aborts the incomplete transfer.
+- Disable Net::HTTP transport retries in non-streaming mode as well as streaming
+  mode, preventing replay with an already-consumed request body.
+
+### Fixed
+
+- Return integer statuses in non-streaming mode and preserve multiple response
+  header values as arrays on Rack 3 (including `Set-Cookie`). Rack 2 keeps its
+  newline-separated representation.
+- Remove entity headers forbidden by Rack on 1xx/204/304 responses. HEAD and
+  304 representation sizes no longer incorrectly trigger the response body cap.
+- Replace a remaining live-host test with a local fixture and simulate failed
+  DNS resolution without sending external DNS queries. Add offline adversarial
+  framing, size-limit, retry, and `Rack::Lint` regression checks.
+
 ## [1.0.2] - 2026-09-01
 
 Housekeeping — no library behavior changes. **No action is needed by users:**
@@ -195,7 +238,8 @@ or a compatible fix. See the README's "Upgrading" section for migration steps.
 
 Older releases (≤ 0.7.8) predate this changelog; see the git history and tags.
 
-[Unreleased]: https://github.com/ncr/rack-proxy/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/ncr/rack-proxy/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/ncr/rack-proxy/compare/v1.0.2...v2.0.0
 [1.0.2]: https://github.com/ncr/rack-proxy/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/ncr/rack-proxy/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/ncr/rack-proxy/compare/v0.8.3...v1.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-proxy (1.0.2)
+    rack-proxy (2.0.0)
       rack (>= 2.0, < 4)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Typical uses:
 Requires Ruby >= 3.0 and Rack 2.x or 3.x. Add to your `Gemfile`:
 
 ```ruby
-gem "rack-proxy", "~> 1.0"
+gem "rack-proxy", "~> 2.0"
 ```
 
 ## Quick start
@@ -116,7 +116,7 @@ Pass options when instantiating (`Rack::Proxy.new(backend: ...)`) or mounting mi
 - `:read_timeout` — per-read timeout in seconds (default `60`).
 - `:open_timeout` — connection-open timeout in seconds.
 - `:write_timeout` — per-write timeout in seconds.
-- `:max_response_length` — cap (in bytes) on the backend response size; a larger response is refused with `502` (streaming aborts once the cap is passed).
+- `:max_response_length` — cap (in bytes) on the backend response body. Oversized declared lengths are refused before reading the body, and each chunk is checked before buffering or forwarding it. Non-streaming responses return `502` on overflow; streaming responses abort if overflow is discovered after sending the headers. HEAD/304 representation lengths do not count as body bytes.
 
 ### Request shaping
 
@@ -240,7 +240,7 @@ From [`examples/example_service_proxy.rb`](examples/example_service_proxy.rb):
 # 1. rails new test_app
 # 2. cd test_app
 # 3. install Rack-Proxy in `Gemfile`
-#    a. `gem 'rack-proxy', '~> 1.0'`
+#    a. `gem 'rack-proxy', '~> 2.0'`
 # 4. install gem: `bundle install`
 # 5. copy the class into your app and mount it from `config/initializers/proxy.rb`
 # 6. run: `SERVICE_URL=http://guides.rubyonrails.org rails server`
@@ -381,6 +381,17 @@ end
 ```
 
 ## Upgrading
+
+### 1.x → 2.0.0
+
+2.0.0 hardens HTTP framing and response limits. Ruby and Rack requirements are unchanged.
+
+- **Automatic transport retries are disabled in both modes.** Non-streaming requests previously inherited Net::HTTP's retry behavior. If your application needs retries, use an explicit policy that considers whether the operation is safe to replay and provides a fresh request body for each attempt.
+- **Response hooks follow Rack's types.** Statuses are integers in both modes. On Rack 3, repeated headers such as `Set-Cookie` are arrays of strings; update hooks that split these values on newlines. Rack 2 still uses newline-separated strings.
+- **Framing errors fail explicitly.** Malformed request lengths and incomplete uploads return `400`. Ambiguous backend framing returns `502`. A truncated backend body returns `502` before headers are sent, or raises during streaming so the server aborts the transfer. Uploads without `CONTENT_LENGTH` are forwarded with chunked encoding; backends must support HTTP/1.1 chunked requests.
+- **Response limits apply before buffering.** `max_response_length` now bounds non-streaming accumulation. HEAD and 304 representation lengths do not count toward the body cap.
+
+Update your Gemfile to `gem "rack-proxy", "~> 2.0"` and run `bundle update rack-proxy`. Existing explicit backend and TLS options continue to work.
 
 ### 0.8.x → 1.0.0
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,13 +7,14 @@ threat model below alongside the "Security considerations" section of the README
 
 ## Supported versions
 
-Security fixes are released for the latest major series. The last `0.x` series
-receives fixes for critical issues only, for a transition period — please
-upgrade to `1.x`.
+Security fixes are released for the latest major series. Older supported
+series receive critical fixes only during their transition period — please
+upgrade to `2.x`.
 
 | Version | Supported |
 | ------- | --------- |
-| 1.0.x   | ✅        |
+| 2.0.x   | ✅        |
+| 1.0.x   | critical fixes only |
 | 0.8.x   | critical fixes only |
 | < 0.8   | ❌        |
 

--- a/examples/example_service_proxy.rb
+++ b/examples/example_service_proxy.rb
@@ -7,7 +7,7 @@
 # 1. rails new test_app
 # 2. cd test_app
 # 3. install Rack-Proxy in `Gemfile`
-#    a. `gem 'rack-proxy', '~> 1.0'`
+#    a. `gem 'rack-proxy', '~> 2.0'`
 # 4. install gem: `bundle install`
 # 5. copy this class into your app (e.g. `app/middleware/example_service_proxy.rb`)
 #    and mount it from `config/initializers/proxy.rb`

--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -135,7 +135,16 @@ module Rack
         @fiber = Fiber.new do
           session.request(request) do |res|
             Fiber.yield res
-            res.read_body { |chunk| Fiber.yield chunk }
+            bytes = 0
+            res.read_body do |chunk|
+              bytes += chunk.bytesize
+              Fiber.yield chunk
+            end
+            # Net::HTTP tolerates premature EOF for Content-Length bodies on
+            # supported Ruby versions. A proxy must signal an incomplete body.
+            if request.response_body_permitted? && res.class.body_permitted? && res.content_length && bytes != res.content_length
+              raise EOFError, "backend response is shorter than Content-Length"
+            end
           end
           :done
         end

--- a/lib/rack/proxy.rb
+++ b/lib/rack/proxy.rb
@@ -37,6 +37,30 @@ module Rack
       Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError
     ].freeze
 
+    class InvalidRequest < StandardError; end
+
+    # Net::HTTP copies a body stream until EOF, even when Content-Length is
+    # smaller. Bound the input so extra bytes cannot become a second request.
+    class RequestBodyStream
+      def initialize(input, length)
+        @input, @remaining = input, length
+      end
+
+      def read(length, buffer = nil)
+        if @remaining.zero?
+          buffer&.clear
+          return nil
+        end
+
+        data = @input.read([length, @remaining].min, buffer)
+        raise InvalidRequest, "request body is shorter than Content-Length" if data.nil? || data.empty?
+
+        @remaining -= data.bytesize
+        data
+      end
+    end
+    private_constant :InvalidRequest, :RequestBodyStream
+
     class << self
       def extract_http_request_headers(env)
         headers = env.reject do |k, v|
@@ -63,7 +87,18 @@ module Rack
 
       def normalize_headers(headers)
         mapped = headers.map do |k, v|
-          [titleize(k), v.is_a?(Array) ? v.join("\n") : v]
+          value = if v.is_a?(Array)
+            if v.length == 1
+              v.first
+            elsif Rack.const_defined?(:Headers, false)
+              v
+            else
+              v.join("\n")
+            end
+          else
+            v
+          end
+          [titleize(k), value]
         end
         build_header_hash mapped.to_h
       end
@@ -115,8 +150,8 @@ module Rack
       @open_timeout = opts[:open_timeout]
       @write_timeout = opts[:write_timeout]
       # Optional cap (in bytes) on the backend response size, to bound memory
-      # against a hostile/huge backend. Enforced incrementally while streaming and
-      # via the declared Content-Length / buffered size otherwise. Default: no cap.
+      # against a hostile/huge backend. Checked before buffering each chunk in
+      # either mode, as well as against declared lengths. Default: no cap.
       @max_response_length = opts[:max_response_length]
       # :ssl_version pins an exact protocol and is deprecated (it forbids TLS 1.3);
       # prefer :min_version / :max_version, which map to Net::HTTP#min_version=/#max_version=.
@@ -223,12 +258,22 @@ module Rack
         # its own content-encoding.
         target_request.instance_variable_set(:@decode_content, false) if target_request.instance_variable_defined?(:@decode_content)
 
-        # Setup body
+        # Rack supplies decoded input. Generate framing for this hop instead
+        # of forwarding the client's Transfer-Encoding or guessing a zero size.
         if target_request.request_body_permitted? && source_request.body
-          target_request.body_stream = source_request.body
-          target_request.content_length = source_request.content_length.to_i
+          input = source_request.body
+          input.rewind if input.respond_to?(:rewind)
+          if (length = source_request.content_length)
+            raise InvalidRequest, "invalid Content-Length" unless /\A[0-9]+\z/.match?(length)
+
+            target_request.content_length = length.to_i
+            target_request.body_stream = RequestBodyStream.new(input, length.to_i)
+          else
+            target_request.delete("Content-Length")
+            target_request["Transfer-Encoding"] = "chunked"
+            target_request.body_stream = input
+          end
           target_request.content_type = source_request.content_type if source_request.content_type
-          target_request.body_stream.rewind if target_request.body_stream.respond_to?(:rewind)
         end
 
         # Use basic auth if we have to
@@ -267,64 +312,93 @@ module Rack
             configure_backend_connection(http, use_ssl: use_ssl, read_timeout: read_timeout)
           end
           target_response.logger = @logger if @logger
+          code = target_response.code
+          headers = prepare_response_headers(target_response.headers, code, target_request)
+          if response_body_permitted?(target_request, code)
+            target_response.max_response_length = @max_response_length
+            body = target_response
+          else
+            target_response.close
+            body = []
+          end
         else
           http = Net::HTTP.new(backend.host, backend.port)
           configure_backend_connection(http, use_ssl: use_ssl, read_timeout: read_timeout)
 
-          target_response = http.start do
-            http.request(target_request)
+          http.start do
+            http.request(target_request) do |response|
+              code = response.code.to_i
+              headers = prepare_response_headers(response.to_hash, code, target_request)
+              body = []
+              if response_body_permitted?(target_request, code)
+                buffered = +"".b
+                response.read_body do |chunk|
+                  check_response_length!(buffered.bytesize + chunk.bytesize)
+                  buffered << chunk
+                end
+                if response.content_length && buffered.bytesize != response.content_length
+                  raise EOFError, "backend response is shorter than Content-Length"
+                end
+                body << buffered unless buffered.empty?
+              end
+            end
           end
         end
-
-        code = target_response.code
-        headers = self.class.normalize_headers(target_response.respond_to?(:headers) ? target_response.headers : target_response.to_hash)
-        body = target_response.body || []
-        body = [body] unless body.respond_to?(:each)
-      rescue URI::InvalidURIError
+      rescue URI::InvalidURIError, InvalidRequest
+        target_response&.close
         return [400, {}, []]
-      rescue *BACKEND_ERRORS => e
+      rescue *BACKEND_ERRORS, HttpStreamingResponse::ResponseTooLarge => e
+        target_response&.close
         @logger << "rack-proxy: backend request failed: #{e.class}: #{e.message}\n" if @logger.respond_to?(:<<)
         return [502, {}, []]
       end
-
-      # No entity body for status codes that don't allow one (1xx, 204, 304)
-      body = [] if Rack::Utils::STATUS_WITH_NO_ENTITY_BODY[code.to_i]
-
-      # Remove hop-by-hop header fields from the response. Use #delete (not
-      # #reject!) so the returned HeaderHash's case-insensitive index stays
-      # consistent on Rack 2 for any downstream middleware.
-      headers.keys.each { |k| headers.delete(k) if HOP_BY_HOP_HEADERS[k.downcase] }
-
-      return [502, {}, []] if response_too_large?(target_response, headers, body)
 
       [code, headers, body]
     end
 
     private
 
-    # Enforce :max_response_length. Returns true (→ 502) when the response is
-    # already known to be too large. For streaming, a declared oversize is
-    # rejected up-front (the connection is closed) and the incremental limit is
-    # armed on the body for chunked/unknown-length responses; for non-streaming,
-    # the body is already buffered so we check its actual size. Returns false
-    # (allow) when no cap is set.
-    def response_too_large?(target_response, headers, body)
-      return false unless @max_response_length
+    def response_body_permitted?(request, code)
+      request.response_body_permitted? && !Rack::Utils::STATUS_WITH_NO_ENTITY_BODY[code] && code != 205
+    end
 
-      declared = headers["Content-Length"]
-      declared_oversize = declared && declared.to_i > @max_response_length
-
-      if target_response.respond_to?(:max_response_length=)
-        if declared_oversize
-          target_response.close
-          return true
-        end
-        target_response.max_response_length = @max_response_length
-        false
-      else
-        buffered = body.sum { |part| part.to_s.bytesize }
-        declared_oversize || buffered > @max_response_length
+    def check_response_length!(length)
+      if @max_response_length && length && length > @max_response_length
+        raise HttpStreamingResponse::ResponseTooLarge, "backend response exceeded max_response_length=#{@max_response_length}"
       end
+    end
+
+    # Validate framing before dropping hop-by-hop fields or reading a body.
+    # Net::HTTP dechunks responses but otherwise preserves their headers.
+    def prepare_response_headers(raw_headers, code, request)
+      # Rack 2 HeaderHash#each joins arrays with newlines. Read values directly
+      # so repeated framing/Connection fields stay distinct during validation.
+      headers = self.class.build_header_hash(raw_headers.keys.map { |key| [key, raw_headers[key]] })
+      transfer_encoding = headers["Transfer-Encoding"]
+      content_length = headers["Content-Length"]
+      if transfer_encoding
+        if content_length || Array(transfer_encoding).join(",").strip.downcase != "chunked"
+          raise Net::HTTPBadResponse, "ambiguous or unsupported backend transfer encoding"
+        end
+      end
+      if content_length
+        lengths = Array(content_length).flat_map { |value| value.split(",", -1).map(&:strip) }
+        unless lengths.all? { |value| /\A[0-9]+\z/.match?(value) } && lengths.map(&:to_i).uniq.length == 1
+          raise Net::HTTPBadResponse, "invalid backend Content-Length"
+        end
+        headers["Content-Length"] = lengths.first.to_i.to_s
+        check_response_length!(lengths.first.to_i) if response_body_permitted?(request, code)
+      end
+
+      connection_named = Array(headers["Connection"]).join(",").downcase.split(",").map(&:strip)
+      headers.keys.each do |key|
+        headers.delete(key) if HOP_BY_HOP_HEADERS[key.downcase] || connection_named.include?(key.downcase)
+      end
+      if Rack::Utils::STATUS_WITH_NO_ENTITY_BODY[code]
+        headers.delete("Content-Length")
+        headers.delete("Content-Type")
+      end
+      self.class.normalize_headers(headers)
     end
 
     # Resolve the Net::HTTP request class for an HTTP method, or nil if there is
@@ -340,6 +414,9 @@ module Rack
     # TLS option — notably the VERIFY_PEER default — can never land on only one.
     def configure_backend_connection(conn, use_ssl:, read_timeout:)
       conn.use_ssl = use_ssl
+      # Request input need not be rewindable. A transport retry could replay an
+      # operation with an empty or partial body, so neither path retries it.
+      conn.max_retries = 0
       conn.read_timeout = read_timeout
       conn.open_timeout = @open_timeout if @open_timeout
       conn.write_timeout = @write_timeout if @write_timeout

--- a/lib/rack/proxy/version.rb
+++ b/lib/rack/proxy/version.rb
@@ -2,6 +2,6 @@
 
 module Rack
   class Proxy
-    VERSION = "1.0.2"
+    VERSION = "2.0.0"
   end
 end

--- a/test/rack_proxy_test.rb
+++ b/test/rack_proxy_test.rb
@@ -132,13 +132,20 @@ class RackProxyTest < Test::Unit::TestCase
 
     headers = proxy_class.normalize_headers(env)
     assert headers["Set-Cookie"].include?("cookie1=foo"), "Include the first value"
-    assert headers["Set-Cookie"].include?("\n"), "Join multiple cookies with newlines"
+    if Rack.const_defined?(:Headers, false)
+      assert_equal ["cookie1=foo", "cookie2=bar"], headers["Set-Cookie"]
+    else
+      assert headers["Set-Cookie"].include?("\n"), "Rack 2 joins multiple cookies with newlines"
+    end
     assert headers["Set-Cookie"].include?("cookie2=bar"), "Include the second value"
   end
 
   def test_handles_missing_content_length
-    assert_nothing_thrown do
-      post "/", nil, "CONTENT_LENGTH" => nil
+    with_webrick_proxy do |port, proxy|
+      proxy.host = "127.0.0.1:#{port}"
+      post "/echo-body", nil, "CONTENT_LENGTH" => nil
+      assert_equal 200, last_response.status
+      assert_equal "", last_response.body
     end
   end
 
@@ -221,13 +228,20 @@ class RackProxyTest < Test::Unit::TestCase
     assert_equal "", last_response.body
   end
 
-  # `.invalid` is reserved (RFC 6761) and never resolves, so this stays
-  # deterministic and offline: the SocketError from a failed DNS lookup must be
-  # mapped to 502, not raised.
+  # Simulate only DNS failure, leaving Net::HTTP's connection path intact.
+  # Even a reserved .invalid name can trigger an external DNS query otherwise.
   def test_unknown_host_returns_502
+    resolver = Addrinfo.method(:getaddrinfo)
+    Addrinfo.define_singleton_method(:getaddrinfo) do |host, *args, **kwargs|
+      raise SocketError, "offline test: host not found" if host == "no-such-host.invalid"
+
+      resolver.call(host, *args, **kwargs)
+    end
     app({streaming: false}).host = "no-such-host.invalid"
     get "/"
     assert_equal 502, last_response.status
+  ensure
+    Addrinfo.define_singleton_method(:getaddrinfo, resolver)
   end
 
   # Issues #122/#123: body should be [] for empty responses and for status

--- a/test/security_regression_test.rb
+++ b/test/security_regression_test.rb
@@ -1,0 +1,231 @@
+require "test_helper"
+require "rack/proxy"
+require "rack/lint"
+
+class SecurityRegressionTest < Test::Unit::TestCase
+  class DeadlineExceeded < StandardError; end
+
+  class NonRewindableInput < StringIO
+    undef_method :rewind
+  end
+
+  def test_unknown_length_upload_is_reframed_without_losing_the_body
+    server, port = ProxyTestServer.start_server
+    payload = "GET /injected HTTP/1.1\r\nHost: internal\r\n\r\n"
+    [true, false].each do |streaming|
+      [nil, "chunked"].each do |encoding|
+        proxy = Rack::Proxy.new(backend: "http://127.0.0.1:#{port}", streaming: streaming)
+        env = Rack::MockRequest.env_for("/echo-body", method: "POST")
+        env.delete("CONTENT_LENGTH")
+        env["CONTENT_TYPE"] = "text/plain"
+        env["HTTP_TRANSFER_ENCODING"] = encoding
+        env["rack.input"] = NonRewindableInput.new(payload)
+        status, _, body = proxy.call(env)
+        assert_equal 200, status
+        assert_equal payload, consume(body), "decoded input must remain the POST body"
+      end
+    end
+  ensure
+    server&.shutdown
+  end
+
+  def test_content_length_bounds_bytes_written_to_backend
+    [true, false].each do |streaming|
+      received = Queue.new
+      handler = lambda do |socket|
+        data = socket.read(5)
+        data << socket.readpartial(4096) if IO.select([socket], nil, nil, 0.02)
+        received << data
+        socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+      end
+      ProxyTestServer.with_raw_backend(handler) do |backend|
+        env = Rack::MockRequest.env_for("/", method: "POST")
+        env["CONTENT_LENGTH"] = "5"
+        env["CONTENT_TYPE"] = "text/plain"
+        env["rack.input"] = StringIO.new("helloGET /injected HTTP/1.1\r\nHost: internal\r\n\r\n")
+        proxy = Rack::Proxy.new(backend: backend, streaming: streaming)
+        status, _, body = proxy.call(env)
+        assert_equal 200, status
+        assert_equal "ok", consume(body)
+        assert_equal "hello", received.pop, "bytes after Content-Length must never reach the backend"
+      end
+    end
+  end
+
+  def test_invalid_request_lengths_return_400
+    [true, false].each do |streaming|
+      ["-1", "5garbage", "5, 6", ""].each do |length|
+        env = Rack::MockRequest.env_for("/", method: "POST", input: "hello")
+        env["CONTENT_LENGTH"] = length
+        assert_equal 400, Rack::Proxy.new(streaming: streaming).call(env).first
+      end
+    end
+  end
+
+  def test_short_request_body_returns_400_and_closes_backend
+    [true, false].each do |streaming|
+      handler = ->(socket) { socket.read }
+      ProxyTestServer.with_raw_backend(handler) do |backend|
+        env = Rack::MockRequest.env_for("/", method: "POST", input: "hello")
+        env["CONTENT_LENGTH"] = "10"
+        env["CONTENT_TYPE"] = "text/plain"
+        proxy = Rack::Proxy.new(backend: backend, streaming: streaming)
+        assert_equal 400, proxy.call(env).first
+      end
+    end
+  end
+
+  def test_ambiguous_and_unsupported_response_framing_returns_502
+    fields = [
+      "Transfer-Encoding: chunked\r\nContent-Length: 1",
+      "Transfer-Encoding: gzip, chunked",
+      "Content-Length: 2\r\nContent-Length: 3",
+      "Content-Length: 2, 3",
+      "Content-Length: 2junk",
+      "Content-Length: -1"
+    ]
+    [true, false].each do |streaming|
+      fields.each do |headers|
+        with_response("HTTP/1.1 200 OK\r\n#{headers}\r\n\r\n", streaming: streaming) do |proxy|
+          status, _, body = proxy.call(Rack::MockRequest.env_for("/"))
+          assert_equal 502, status, headers
+          assert_equal "", consume(body)
+        end
+      end
+    end
+  end
+
+  def test_equal_duplicate_content_lengths_are_normalized
+    [true, false].each do |streaming|
+      with_response("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Length: 2\r\n\r\nok", streaming: streaming) do |proxy|
+        status, headers, body = proxy.call(Rack::MockRequest.env_for("/"))
+        assert_equal 200, status
+        assert_equal "2", headers["Content-Length"]
+        assert_equal "ok", consume(body)
+      end
+    end
+  end
+
+  def test_response_connection_tokens_are_removed_across_multiple_fields
+    wire = "HTTP/1.1 200 OK\r\nConnection: X-Internal\r\nConnection: close, X-Other\r\n" \
+           "X-Internal: secret\r\nX-Other: secret\r\nX-End-To-End: public\r\nContent-Length: 2\r\n\r\nok"
+    [true, false].each do |streaming|
+      with_response(wire, streaming: streaming) do |proxy|
+        _, headers, body = proxy.call(Rack::MockRequest.env_for("/"))
+        %w[Connection X-Internal X-Other].each { |key| assert_nil headers[key] }
+        assert_equal "public", headers["X-End-To-End"]
+        assert_equal "ok", consume(body)
+      end
+    end
+  end
+
+  def test_truncated_content_length_response_is_never_successful
+    [true, false].each do |streaming|
+      with_response("HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nhello", streaming: streaming) do |proxy|
+        status, _, body = proxy.call(Rack::MockRequest.env_for("/"))
+        if streaming
+          assert_equal 200, status
+          assert_raise(EOFError) { consume(body) }
+          assert !body.instance_variable_get(:@session).started?
+        else
+          assert_equal 502, status
+          assert_equal "", consume(body)
+        end
+      end
+    end
+  end
+
+  def test_buffered_response_limit_aborts_before_reading_the_whole_body
+    # Neither response completes: a size cap must close the connection without
+    # waiting for the rest of a declared or chunked body to arrive.
+    ["Content-Length: 100\r\n\r\n",
+      "Connection: Content-Length\r\nContent-Length: 100\r\n\r\n",
+      "Transfer-Encoding: chunked\r\n\r\nB\r\nhello world\r\n"].each do |prefix|
+      handler = lambda do |socket|
+        socket.write("HTTP/1.1 200 OK\r\n#{prefix}")
+        socket.read
+      end
+      ProxyTestServer.with_raw_backend(handler) do |backend|
+        proxy = Rack::Proxy.new(backend: backend, streaming: false, max_response_length: 10)
+        Timeout.timeout(2, DeadlineExceeded) do
+          assert_equal 502, proxy.call(Rack::MockRequest.env_for("/")).first
+        end
+      end
+    end
+  end
+
+  def test_backend_failure_does_not_replay_request_in_either_mode
+    [true, false].each do |streaming|
+      handler = ->(socket) { socket.close }
+      ProxyTestServer.with_raw_backend(handler) do |backend|
+        proxy = Rack::Proxy.new(backend: backend, streaming: streaming)
+        # A retry would connect to the still-listening socket without a handler
+        # and stall. The first failed exchange must return immediately.
+        Timeout.timeout(2, DeadlineExceeded) do
+          assert_equal 502, proxy.call(Rack::MockRequest.env_for("/")).first
+        end
+      end
+    end
+  end
+
+  def test_rejected_streaming_response_closes_backend_connection
+    ["Content-Length: 100", "Transfer-Encoding: chunked\r\nContent-Length: 1"].each do |headers|
+      closed = Queue.new
+      handler = lambda do |socket|
+        socket.write("HTTP/1.1 200 OK\r\n#{headers}\r\n\r\n")
+        closed << socket.read
+      end
+      ProxyTestServer.with_raw_backend(handler) do |backend|
+        proxy = Rack::Proxy.new(backend: backend, max_response_length: 10)
+        Timeout.timeout(2, DeadlineExceeded) do
+          assert_equal 502, proxy.call(Rack::MockRequest.env_for("/")).first
+          assert_equal "", closed.pop, "rejecting headers must release the suspended stream's socket"
+        end
+      end
+    end
+  end
+
+  def test_head_response_size_limit_does_not_limit_representation_size
+    [true, false].each do |streaming|
+      with_response("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n", streaming: streaming, max_response_length: 10) do |proxy|
+        status, headers, body = proxy.call(Rack::MockRequest.env_for("/", method: "HEAD"))
+        assert_equal 200, status
+        assert_equal "100", headers["Content-Length"]
+        assert_equal "", consume(body)
+      end
+    end
+  end
+
+  def test_responses_pass_rack_lint_in_both_modes
+    [true, false].each do |streaming|
+      [200, 204, 304].each do |code|
+        wire = "HTTP/1.1 #{code} Test\r\nSet-Cookie: a=1\r\nSet-Cookie: b=2\r\n" \
+               "Content-Type: text/plain\r\nContent-Length: 2\r\n\r\n"
+        wire << "ok" if code == 200
+        with_response(wire, streaming: streaming) do |proxy|
+          status, headers, body = Rack::Lint.new(proxy).call(Rack::MockRequest.env_for("/"))
+          assert_equal code, status
+          assert_equal((code == 200) ? "ok" : "", consume(body))
+          cookies = headers["set-cookie"] || headers["Set-Cookie"]
+          assert_equal ["a=1", "b=2"], cookies.is_a?(Array) ? cookies : cookies.split("\n")
+        end
+      end
+    end
+  end
+
+  private
+
+  def consume(body)
+    result = +"".b
+    body.each { |chunk| result << chunk }
+    result
+  ensure
+    body.close if body.respond_to?(:close)
+  end
+
+  def with_response(wire, **options)
+    ProxyTestServer.with_raw_backend(->(socket) { socket.write(wire) }) do |backend|
+      yield Rack::Proxy.new(backend: backend, **options)
+    end
+  end
+end

--- a/test/support/proxy_test_server.rb
+++ b/test/support/proxy_test_server.rb
@@ -26,6 +26,26 @@ require "tempfile"
 module ProxyTestServer
   module_function
 
+  # For malformed framing and incomplete transfers that WEBrick would repair.
+  # The handler receives a real socket after the request headers are consumed.
+  def with_raw_backend(handler)
+    server = TCPServer.new("127.0.0.1", 0)
+    thread = Thread.new do
+      client = server.accept
+      client.gets("\r\n\r\n")
+      handler.call(client)
+    rescue IOError, Errno::EPIPE, Errno::ECONNRESET
+      # Rejecting a response is expected to close the socket early.
+    ensure
+      client&.close
+    end
+    yield "http://127.0.0.1:#{server.addr[1]}"
+  ensure
+    thread&.kill
+    thread&.join
+    server&.close
+  end
+
   # Starts a server on an ephemeral port bound to 127.0.0.1 and returns
   # [server, port]. Pass ssl: true for HTTPS. By default the cert is self-signed
   # (untrusted on purpose — exercises the VERIFY_PEER default rejecting it). Pass


### PR DESCRIPTION
This release fixes unsafe HTTP request framing, validates backend response framing, enforces response limits before buffering, and makes truncated responses fail explicitly. It also strips response headers named by Connection and corrects Rack response types and repeated headers.

The version is 2.0.0 under the repository's major-release policy: non-streaming transport retries are disabled to prevent replay with consumed input, and response hooks now receive Rack-compliant statuses and header values. The README includes an upgrade guide; the version and Gemfile.lock are updated together.

Validation:

- 97 tests and 301 assertions passed locally on Rack 2 and Rack 3 using Ruby 3.3.4; two opt-in live tests omitted.
- 13 new offline regressions cover framing, upload boundaries, response limits, truncation, socket cleanup, retries, and Rack::Lint.
- Coverage: 98.95% lines and 90.19% branches; existing floors maintained.
- Standard, gem build, and the updated dependency advisory audit passed.
- This PR runs the full Ruby 3.1–3.4 × Rack 2/3 matrix, Ruby-head canary, and CI lint/audit/coverage/build jobs before merge.

The TLS VERIFY_PEER default, explicit dynamic-backend opt-in, streaming Fiber teardown, gzip pass-through, and X-Forwarded-For behavior remain covered by the suite.
